### PR TITLE
fix(repo-scanner): wrong org owner + multi-line JSON output crash

### DIFF
--- a/.github/workflows/repo-scanner.yml
+++ b/.github/workflows/repo-scanner.yml
@@ -19,7 +19,7 @@ permissions:
   pull-requests: write
 
 env:
-  GH_OWNER: timothyhartzog
+  GH_OWNER: ruralpeds
 
 jobs:
   scan:
@@ -36,7 +36,8 @@ jobs:
           if [ -n "${{ inputs.target-repo }}" ]; then
             echo 'repos=["${{ inputs.target-repo }}"]' >> $GITHUB_OUTPUT
           else
-            REPOS=$(gh repo list "$GH_OWNER" --json name --limit 100 -q '.[].name' | jq -R -s 'split("\n") | map(select(length > 0))')
+            REPOS=$(gh repo list "$GH_OWNER" --json name --limit 100 -q '.[].name' | jq -R -s 'split("
+") | map(select(length > 0))' | jq -c '.')
             echo "repos=$REPOS" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
Fixes two bugs:
- GH_OWNER was hardcoded to `timothyhartzog` instead of `ruralpeds`
- Multi-line JSON from `jq` crashed `GITHUB_OUTPUT` — fixed with `jq -c`