### PR TITLE
fix: seed workflow dry-run flag

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+
+# Agentic pipeline — sensitive paths require human review
+/AGENTS.md                             @ruralpeds/security @ruralpeds/clinical
+/.github/copilot-instructions.md       @ruralpeds/security
+/.github/instructions/dhf*             @ruralpeds/clinical
+/.github/instructions/security*        @ruralpeds/security
+/policies/**                           @ruralpeds/security
+/audit-log/**                          @ruralpeds/security
+/copilot-tasks/**                      @ruralpeds/engineering

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,180 @@
+name: Agent-actionable task
+description: A scoped task ready for an AI coding agent (Copilot, Claude Code, Codex) to execute.
+title: "[agent-task] <phase>/<slug>: <short description>"
+labels: ["agent-task", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Agent task
+
+        This issue is intended to be picked up by an AI coding agent. Before filling this out, verify the task is scoped to a single, testable, reviewable change.
+
+        **If the task is larger than ~400 diff lines or requires clinical judgment, do not file as an agent task.** Break it down first.
+
+  - type: input
+    id: phase
+    attributes:
+      label: Roadmap phase
+      description: Phase number (1–12) from the ENTERPRISE_ROADMAP.md
+      placeholder: "phase-01"
+    validations:
+      required: true
+
+  - type: input
+    id: slug
+    attributes:
+      label: Task slug
+      description: kebab-case identifier matching the task file under copilot-tasks/phase-NN-*/
+      placeholder: "pin-actions-sha"
+    validations:
+      required: true
+
+  - type: input
+    id: task-file
+    attributes:
+      label: Linked task file
+      description: Path (in the .github repo) to the machine-readable task spec
+      placeholder: "copilot-tasks/phase-01-platform-hardening/task-02-pin-actions-sha.md"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: target-agent
+    attributes:
+      label: Preferred agent
+      description: Which agent should pick this up
+      options:
+        - copilot
+        - claude-code
+        - codex
+        - any
+    validations:
+      required: true
+
+  - type: dropdown
+    id: iec-class
+    attributes:
+      label: Repo IEC 62304 class
+      description: Copy from the repo's custom property. Tasks against Class C repos require extra human review.
+      options:
+        - not-applicable
+        - class-a
+        - class-b
+        - class-c
+    validations:
+      required: true
+
+  - type: dropdown
+    id: data-classification
+    attributes:
+      label: Repo data classification
+      description: Copy from the repo's custom property.
+      options:
+        - public
+        - internal
+        - synthetic
+        - phi-capable
+        - phi-active
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal (plain language)
+      description: What this task accomplishes. Two sentences max.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Testable outcomes. The agent's PR is not "done" until every box is checked.
+      value: |
+        - [ ] <criterion 1>
+        - [ ] <criterion 2>
+        - [ ] <criterion 3>
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-to-touch
+    attributes:
+      label: Files the agent may modify
+      description: Explicit allow-list. Anything not listed is out of scope.
+      placeholder: |
+        - .github/workflows/ci-node.yml
+        - .github/workflows/ci-rust.yml
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-not-to-touch
+    attributes:
+      label: Files the agent MUST NOT modify
+      description: Anything from AGENTS.md §4.3 plus task-specific exclusions.
+      value: |
+        - audit-log/**
+        - dhf/risk/**
+        - policies/rulesets/**
+        - .github/workflows/audit-log.yml
+        - .github/workflows/audit-verify.yml
+        - AGENTS.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests-required
+    attributes:
+      label: Tests required
+      description: What new or modified tests must accompany this change
+    validations:
+      required: true
+
+  - type: textarea
+    id: standards
+    attributes:
+      label: Standards touched
+      description: Cite the regulatory / industry standards this change implements or affects
+      placeholder: "NIST SSDF PW.4, HIPAA §164.312(b), IEC 62304 §5.5"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: preflight-confirmation
+    attributes:
+      label: Require preflight confirmation?
+      description: Should the agent list its planned file changes and wait for a human comment before editing?
+      options:
+        - "false"
+        - "true"
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback plan
+      description: How to revert if this lands and breaks something
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: agent-ready
+    attributes:
+      label: Agent readiness checklist
+      description: Confirm before assigning to an agent
+      options:
+        - label: "Task is scoped to a single reviewable change (< 400 diff lines)"
+          required: true
+        - label: "Acceptance criteria are testable"
+          required: true
+        - label: "No clinical judgment required beyond what's written here"
+          required: true
+        - label: "Files-to-touch list is explicit"
+          required: true
+        - label: "Task file exists under copilot-tasks/"
+          required: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,162 @@
+# GitHub Copilot Instructions — ruralpeds
+
+You are working inside a `ruralpeds/*` repository. The organization builds clinical and scientific software for healthcare. Treat everything in this repo as safety-relevant and regulatory-relevant unless a file explicitly marks it otherwise.
+
+**Authoritative context:** Always read `AGENTS.md` at the repo root before proposing code. It contains the cross-agent contract and is strictly more authoritative than these Copilot-specific instructions.
+
+**Also read, when relevant:**
+
+- `.github/instructions/*.md` — path-scoped instructions that auto-apply based on file location.
+- `copilot-tasks/phase-NN-*/task-*.md` — the machine-readable task file linked from any issue you're working on.
+- `docs/compliance/STANDARDS_MAP.md` — which regulatory standards apply to this repo.
+- `dhf/classification.md` — the repo's IEC 62304 software safety class, if present.
+- `README.md` at the repo root.
+
+## Operating modes
+
+You may be invoked in one of three modes. Behavior differs.
+
+### 1. Inline completion / chat
+
+Short, surgical suggestions. Apply these instructions to every completion. Do not invent APIs; if unsure, say so.
+
+### 2. Code review (PR review mode)
+
+Look specifically for:
+
+- Violations of hard refusals in `AGENTS.md §1`.
+- PHI patterns in added/changed code or fixtures.
+- Missing tests for behavior changes.
+- Missing audit events for privileged or patient-impacting operations.
+- Dependency additions that skip the approval path.
+- Workflow changes that weaken required checks.
+- Uncaught exceptions without correlation IDs.
+- Logging statements that could leak identifiers.
+
+Give concrete, line-referenced suggestions. Prefer "request changes" when any `AGENTS.md §1` rule is violated.
+
+### 3. Coding agent (when assigned to an issue)
+
+This is the fully autonomous mode. Before writing any code:
+
+1. Read the linked task file end to end.
+2. Read `AGENTS.md`.
+3. Read every `.github/instructions/*.md` whose `applyTo` pattern matches any file you plan to touch.
+4. List the files you intend to modify, as a comment on the issue, and wait for confirmation **only if** the task file's `preflight-confirmation` flag is `true`. Otherwise proceed.
+5. Execute, test, and open a PR following `AGENTS.md §3`.
+
+## Repository conventions
+
+- Branch naming: `agent/<phase>/<slug>-<issue#>`. Example: `agent/phase-01/pin-actions-sha-42`.
+- Commit style: Conventional Commits with `Refs: #<issue>` footer.
+- PR titles: start with the type + short description, e.g. `security: pin all workflow actions to SHAs`.
+- One task per PR. No drive-by fixes.
+
+## Language-specific defaults (applied when you're in a matching file)
+
+### Julia
+
+- Formatter: `JuliaFormatter.jl` with the repo's `.JuliaFormatter.toml`.
+- Static analysis: `JET.jl`, `Aqua.jl` — both should run clean.
+- Every exported function needs a docstring with `# Arguments`, `# Returns`, `# Examples`.
+- No global mutable state in packages.
+- Use `@assert` for invariants only, never for input validation (may be disabled in `-O3`).
+
+### Rust
+
+- Formatter: `rustfmt` with default profile unless `rustfmt.toml` overrides.
+- Lints: `cargo clippy -- -D warnings`.
+- Prefer `Result<T, thiserror::Error>` over `anyhow` in library crates.
+- All public fns have `///` doc comments.
+- No `unsafe` without a `// SAFETY: <rationale>` comment above each use.
+- No `unwrap()` or `expect()` in non-test code except where a panic is the correct behavior — then comment why.
+
+### Python
+
+- Formatter: `ruff format`. Linter: `ruff check` with strict config.
+- Types: `mypy --strict`. Every public function has type hints.
+- No `from module import *`.
+- Use `pathlib.Path`, not `os.path`.
+- Tests use `pytest`, not `unittest`.
+
+### TypeScript/JavaScript
+
+- Formatter: `prettier` with the repo's `.prettierrc`.
+- Linter: `eslint` with strict TS ruleset.
+- `strictNullChecks`, `noImplicitAny`, `strict` — all on.
+- No `any`. Use `unknown` and narrow, or model the type.
+- No `// @ts-ignore` without `// @ts-expect-error: <reason>` and an issue link.
+
+### Go
+
+- Formatter: `gofmt` or `gofumpt`. Linter: `golangci-lint` with the repo's `.golangci.yml`.
+- All errors wrapped with context: `fmt.Errorf("doing X: %w", err)`.
+- No `panic` outside `main.go` initialization.
+- Context propagation mandatory: every function that does I/O takes `ctx context.Context` as the first argument.
+
+## What not to do (Copilot-specific reminders)
+
+- **Do not invent function names or package APIs.** If you're not sure a function exists, don't call it. Use the LSP/indexer to verify.
+- **Do not delete tests to make CI green.** Ever.
+- **Do not silence warnings** by suppressing them (`// eslint-disable`, `# type: ignore`, `@ts-ignore`, `allow(unused)`). Fix the underlying issue, or escalate with `RISK:` comment.
+- **Do not introduce a new dependency** in the middle of a task. If a task needs one, open a separate dependency-add PR first.
+- **Do not modify `AGENTS.md`, `.github/copilot-instructions.md`, or files under `policies/`** unless that is the explicit task.
+- **Do not rewrite existing code stylistically** if the task is about something else. Respect the existing style; open a follow-up if you see real issues.
+- **Do not emit non-ASCII quotes, em-dashes, or fancy unicode** in code unless the file is user-facing prose. Source code uses straight quotes.
+
+## PR description auto-template
+
+When you open a PR, fill this exactly:
+
+```markdown
+## Summary
+
+<2-3 sentence plain-language summary>
+
+## Files Changed
+
+- `path/to/file` — <one-line rationale>
+
+## Acceptance Criteria (from task-XX)
+
+- [x] Criterion 1
+- [x] Criterion 2
+- [ ] Criterion 3 — <explanation of partial>
+
+## Tests
+
+- Added: `tests/path/to/new_test.ext`
+- Modified: `tests/path/to/existing_test.ext`
+- Run locally: `<exact command>` → green.
+
+## Audit Events
+
+- `event.name.changed` — added/modified/none
+
+## Security Implications
+
+- <list or "None; no auth/network/data-handling change">
+
+## Standards Touched
+
+- NIST SSDF <practice>, HIPAA §<section>, IEC 62304 §<section>
+
+## Rollback
+
+<one sentence>
+
+## Agent Self-Check
+
+- [x] Read AGENTS.md
+- [x] Read task file
+- [x] Read applicable instructions/*.md
+- [x] Diff scoped per task
+- [x] No forbidden files modified
+- [x] Tests green locally
+- [x] Lint/format/types green
+- [x] Labels set
+```
+
+## Escalation
+
+If you can't complete the task safely, comment on the issue with `ASK:`, `BLOCKED:`, `RISK:`, `SPLIT:`, or `DONE-PARTIAL:` per `AGENTS.md §10`, and stop. Do not work around. Do not bundle unrelated work. Do not rewrite requirements.

--- a/.github/instructions/dhf.instructions.md
+++ b/.github/instructions/dhf.instructions.md
@@ -1,0 +1,83 @@
+---
+applyTo: "dhf/**"
+---
+
+# Instructions: Design History File (IEC 62304 / ISO 14971)
+
+**STOP.** Files under `dhf/` are regulated documentation. Read this whole file before making any change.
+
+## Absolute rules
+
+- **Never edit anything under `dhf/risk/`.** Hazard analysis, risk controls, and residual-risk documents require a named clinical reviewer and a formal risk-review cycle. Not overridable by task instruction.
+- **Never edit `dhf/classification.md`** (the software safety class). This is set once per repo by a human and changes only via a full re-classification event.
+- **Never delete a released version directory** under `dhf/releases/<version>/`. Released artifacts are immutable evidence. Append only.
+- **Never change requirement IDs.** `SW-###`, `SYS-###`, `UN-###`, `RC-###`, `HZ-###` are stable identifiers referenced from source code, tests, and audit records. New requirements get new IDs (monotonically increasing); old IDs are retired, never renumbered or reused.
+
+## What you may do
+
+- Add new requirements to `dhf/requirements/software-requirements.yaml` with a new `SW-###` ID greater than the current maximum.
+- Add new test-to-requirement mappings in `dhf/verification/unit-test-map.yaml` or `integration-map.yaml`.
+- Update status fields (`implemented`, `verified`, `released-in`) on existing requirements when the corresponding code/test lands — but only if the code/test lands in the same PR.
+- Add new release directories under `dhf/releases/<version>/` when cutting a release (release workflow responsibility; an agent should almost never do this directly).
+
+## Schema for `software-requirements.yaml`
+
+```yaml
+requirements:
+  - id: SW-042
+    title: "Validate gestational age input range"
+    parent: SYS-011
+    description: >
+      The function MUST reject gestational age inputs outside the range 22w0d..44w6d
+      and MUST emit a clinical.input.rejected audit event with the offending value hashed.
+    type: functional           # functional | interface | safety | performance
+    priority: high             # low | medium | high | critical
+    risk-controls: [RC-007]
+    implemented:
+      location: "src/gestational_age.rs:validate_ga"
+      commit: 3f4a1b...
+      date: 2026-04-23
+    verified:
+      tests:
+        - "tests/unit/test_ga_validation.rs::test_rejects_below_22w"
+        - "tests/unit/test_ga_validation.rs::test_rejects_above_44w6d"
+      date: 2026-04-23
+    released-in: "v1.4.0"
+    status: released           # draft | implemented | verified | released | retired
+    references:
+      - "AAP Perinatal Guidelines 8th ed. Ch 3"
+      - "ACOG Committee Opinion 700"
+```
+
+## Schema for `unit-test-map.yaml`
+
+```yaml
+mappings:
+  - test: "tests/unit/test_ga_validation.rs::test_rejects_below_22w"
+    verifies: [SW-042]
+    type: boundary-value
+    last-run: 2026-04-23
+    last-result: passed
+```
+
+## When adding a new requirement
+
+1. Assign the next `SW-###` ID (look for max, add 1).
+2. Link to a parent system or user requirement.
+3. Write the requirement as a single `MUST`/`MUST NOT`/`SHOULD` statement, testable in isolation.
+4. Identify applicable risk controls (ask in the PR if unclear — do not invent RC-### IDs).
+5. If adding in the same PR as the implementation: fill `implemented` and `verified` fields.
+6. If not: leave as `status: draft` with those fields empty. A follow-up PR fills them.
+
+## When modifying existing source that is annotated `@requirement SW-###`
+
+- The requirement's `implemented.commit` and `implemented.date` must be updated in the same PR.
+- If the behavior change affects the requirement statement itself, the requirement must be retired (`status: retired`) and a new ID issued. Never silently change requirement text — that breaks audit trail.
+- A note is added to `dhf/requirements/history.md` describing the retirement rationale.
+
+## PRs touching `dhf/` always
+
+- Include the label `dhf-change`.
+- Are reviewed by `@ruralpeds/clinical` (not just `@ruralpeds/engineering`).
+- Have commit type `dhf:` per Conventional Commits.
+- Include in PR body the standards cited: `IEC 62304 §<section>`, `ISO 14971 §<section>`.

--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -1,0 +1,55 @@
+---
+applyTo: "src/**/auth/**,src/**/authz/**,src/**/audit/**,src/**/security/**,src/**/crypto/**"
+---
+
+# Instructions: Security-Sensitive Code
+
+Code under these paths implements authentication, authorization, audit logging, cryptographic operations, or security boundaries. Apply extra caution.
+
+## Absolute rules
+
+- **Never roll your own crypto.** Use the language's vetted crypto library: Rust `ring` or `RustCrypto`, Python `cryptography`, Go `crypto/*`, Node `node:crypto`, Julia `Nettle` or `SHA`. If you're tempted to write a primitive, stop and ask.
+- **Never compare secrets with `==` or `strcmp`.** Use constant-time comparison (`subtle::ConstantTimeEq`, `hmac.compare_digest`, `crypto.timingSafeEqual`, `Nettle.constant_time_compare`).
+- **Never log the following**, even at DEBUG level: passwords, tokens, signed URLs, API keys, session IDs, authorization codes, MFA codes, CSRF tokens, signing keys, cookies, raw MRN, raw DOB, raw name, raw address, raw phone, raw email of patients.
+- **Never disable TLS verification.** `rejectUnauthorized: false`, `verify=False`, `InsecureSkipVerify: true`, `ssl_verify: false` — all forbidden. If connecting to a self-signed server, pin a CA explicitly.
+- **Never commit** a private key, `.pem`, `.key`, `.p12`, `.jks`, `.keystore`, or anything that looks like one.
+
+## Required patterns
+
+### Authorization (authz)
+
+- Deny-by-default. A missing policy decision is a deny.
+- Check authz as close to the resource as possible, not just at the route. Layered: route guard → service guard → repository guard.
+- Every authz denial emits an audit event: `auth.access.denied` with the actor, resource, and reason.
+
+### Audit events
+
+- Every privileged or patient-impacting action emits an audit event *before* returning to the caller. Event emission is not best-effort; if the audit pipeline is down, the action fails.
+- Audit event field schema per `docs/audit-events.yaml`. Fields not in the schema are not added without a schema PR first.
+- Audit events are immutable. Never `UPDATE` an emitted event; emit a correction event that references the prior event.
+- Audit events are attributable. `actor_id` is always populated; system actions use `actor_id: "system:<service-name>"` with a separate `reason` field.
+
+### Correlation IDs
+
+- Generated at ingress if not present in the request (`X-Correlation-ID` header, or equivalent).
+- Format: `uuidv4` or `uuidv7`. Validate format on ingress; reject malformed.
+- Propagated to every downstream call and log line.
+
+### Secrets
+
+- Read from environment or a secret manager at startup or on rotation; never at request time except via a cached client.
+- Never pass secrets through the URL, query string, or logs.
+- Secret rotation must be graceful: accept old and new for a transition window, then cut over.
+
+### Cryptographic operations
+
+- Signing: cosign keyless OIDC for anything release-related; per-service signing keys only for application-layer signatures, and only via KMS-backed HSM.
+- Encryption at rest: envelope encryption (per-record DEK, KMS-wrapped KEK). The application never sees the plaintext KEK.
+- Key rotation documented in `docs/security/key-rotation.md` with rotation cadence.
+
+## PRs touching these paths
+
+- Label `security-review-required`.
+- Reviewed by `@ruralpeds/security` (required CODEOWNER).
+- Threat-model note added to the PR body: "What new surface does this add? What does an attacker gain if they compromise the new surface?"
+- If the change alters authz, audit, or crypto behavior, a targeted negative test is added (access denial, audit-event-emission-failure, tampered signature, expired key).

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,91 @@
+---
+applyTo: "tests/**,e2e/**,**/*_test.{rs,py,jl,go,ts,js}"
+---
+
+# Instructions: Tests
+
+## Hard rules
+
+- **Never use real patient data.** All fixtures are synthetic (Synthea-generated or manually constructed with obviously-synthetic names like "TESTPATIENT Alpha, MRN 000-TEST-001").
+- **Tests are deterministic.** No wall-clock time without injection, no `random()` without a fixed seed, no network without mocking, no real filesystem outside `tmpdir`.
+- **Tests are isolated.** Each test sets up and tears down its own state. Order independence — `pytest -p random-order`, `cargo test` parallel, etc., must all pass.
+- **Never skip a test** to make CI green. `@pytest.mark.skip`, `#[ignore]`, `describe.skip`, `t.Skip()` — require a linked issue and a deadline in the comment.
+- **Never weaken an assertion** to make a flaky test pass. Flake = investigate and fix; if truly environmental, document.
+
+## Test categories and conventions
+
+### Unit
+
+- File naming: `test_*.{rs,py,jl,go,ts}` or `*_test.{rs,go}` per language norms.
+- One logical assertion cluster per test function.
+- Arrange / Act / Assert structure with blank lines separating.
+
+### Integration
+
+- Under `tests/integration/` (Python/Rust) or `e2e/integration/` (Node/TS).
+- May spin up real Postgres, Redis, etc. via Testcontainers or the repo's `make up-testenv`.
+- Each test must restore state; no cross-test leakage.
+
+### Contract tests
+
+- Every external-facing API has a contract test verifying the OpenAPI/FHIR/asyncapi spec.
+- Breaking change to the contract = major version bump + migration note.
+
+### Property-based tests (MANDATORY for clinical calcs)
+
+For any function in `src/clinical/`, `src/dose/`, `src/growth/`, `src/lab*/`, or equivalents:
+
+- Use the language's property-based tester: `proptest` (Rust), `hypothesis` (Python), `PropCheck.jl` / `Supposition.jl` (Julia), `fast-check` (TS), `gopter` (Go).
+- Cover at minimum:
+  - **Boundary values** — zero, negative (reject), max, max+1, very small, very large.
+  - **NaN / Inf / denormal** — all must be handled or rejected explicitly.
+  - **Unit confusion** — every accepted unit and every rejected one.
+  - **Tenfold errors** — `value * 10` must not be silently accepted for quantities with human-realistic ranges.
+  - **Extreme ages** — 0-minute-old, 50+ years for pediatric calcs.
+  - **Temporal edges** — DST transitions, leap seconds, midnight-UTC, year boundaries.
+- Shrinking configured; failing cases reported with minimal counterexample.
+
+### E2E (Playwright)
+
+- Under `e2e/playwright/`.
+- Use semantic / accessible locators (`getByRole`, `getByLabel`), not CSS selectors on auto-generated class names.
+- Always capture trace, screenshot, video on failure (already configured in the reusable workflow).
+- Tests run against a test instance seeded with synthetic Synthea patients.
+
+### Mutation tests
+
+- Weekly, not per-PR (expensive).
+- Target modules are listed in `tests/mutation-targets.txt`.
+- Kill rate gates per `AGENTS.md §6`.
+
+### Accessibility tests
+
+- Every Playwright test for a UI includes an `axe-core` scan before exit.
+- WCAG 2.2 AA violations of severity `serious` or `critical` fail the test.
+
+### PHI-leak tests
+
+- For any service that emits logs: a targeted test runs a synthetic patient through the service and asserts no identifier appears in the captured log stream.
+- Use a known synthetic patient with distinctive name `PHITEST-CANARY` and MRN `999-PHI-CANARY`. If the canary appears in logs, the test fails.
+
+## Test naming
+
+Prefer sentence-style names that describe the behavior and the condition:
+
+- ✅ `test_rejects_gestational_age_below_22_weeks`
+- ✅ `test_emits_audit_event_on_dose_override`
+- ❌ `test_ga_1`, `test_validate`, `test_works`
+
+## What NOT to test
+
+- Do not test the compiler, the standard library, or third-party dependencies (unless you genuinely are wrapping a gotcha — then comment why).
+- Do not test through multiple layers if you could test in isolation. Use unit > integration > E2E, and prefer the lowest feasible level.
+- Do not write tests that assert on internal implementation details that the caller shouldn't care about.
+
+## Test data
+
+- Fixtures under `tests/fixtures/`:
+  - `tests/fixtures/synthetic-patients/` — Synthea output, committed (or downloaded on demand via the fixtures workflow).
+  - `tests/fixtures/fhir/` — hand-crafted FHIR resources with the `"meta": {"tag": [{"code": "SYNTHETIC"}]}` marker.
+  - `tests/fixtures/hl7v2/` — synthetic HL7v2 messages.
+- Never add a fixture without the `SYNTHETIC` marker somewhere in its content and filename.

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -1,0 +1,38 @@
+---
+applyTo: ".github/workflows/**/*.yml"
+---
+
+# Instructions: GitHub Actions Workflows
+
+When editing or creating workflows in `.github/workflows/`, apply these rules in addition to `AGENTS.md` and `.github/copilot-instructions.md`.
+
+## Hard rules
+
+- **Pin every `uses:` to a full 40-character commit SHA.** Never use `@main`, `@v1`, `@v1.2.3`, or any tag as the sole reference. The correct form is `uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2` — the SHA is authoritative; the trailing comment is for humans and Dependabot.
+- **Never use `continue-on-error: true`** on a security, test, PHI scan, SBOM, or audit step. If a step is advisory, make that explicit in a separate `warning-only-*` job that doesn't block merge, and document why.
+- **Never use `if: false`** to disable a job. Delete the job (and document the removal in the PR body) or fix it.
+- **`permissions:` must be declared at the workflow level or per-job, always minimal.** Default to `permissions: contents: read`. Elevate only the specific permissions needed. Never use `permissions: write-all`.
+- **No secrets in step output.** Do not `echo "$MY_SECRET"`, do not use secrets in conditional expressions visible in logs, do not `set -x` when a secret is in the environment.
+- **No curl-bash.** Never `curl ... | bash` or `wget ... | sh`. Install via package manager, a pinned action, or a script you've committed.
+- **Use `actions/checkout` with `persist-credentials: false`** unless the job must push back (only audit-log.yml and a handful of others do).
+- **Concurrency required.** Every workflow declares a `concurrency:` block with `cancel-in-progress: true` for PR-triggered workflows (except release workflows).
+- **Timeout required.** Every job declares `timeout-minutes:` with a realistic limit. Default 15 for CI, 45 for E2E, 60 for chaos/load.
+
+## Structure
+
+- Workflows in this `.github` org-template repo that are meant to be called by other repos use the `workflow_call:` trigger and live with the prefix `reusable-*.yml` or `ci-*.yml`.
+- A workflow that scans all org repos lives here and uses `schedule:` + `workflow_dispatch:` triggers; these require a GitHub App token (see org secret `TH_BOT_APP_ID` / `TH_BOT_PRIVATE_KEY`), never a long-lived PAT.
+- Every reusable workflow documents its `inputs:`, `secrets:`, and `outputs:` with comments.
+
+## OIDC / cloud federation
+
+- When authenticating to AWS, GCP, Azure, or other cloud providers, use OIDC (`id-token: write` permission + the provider's OIDC action). Never store long-lived cloud credentials in GitHub secrets.
+- `cosign` signing uses keyless OIDC flow via Fulcio/Rekor. Do not configure cosign with a local private key unless explicitly tasked to.
+
+## Before opening the PR
+
+Run these locally (or in a scratch branch) and include the output in the PR:
+
+- `actionlint` against every file you touched.
+- `yamllint` (strict).
+- For reusable workflows: a smoke test that calls the workflow from a scratch caller in a throwaway repo.

--- a/.github/mcp-config.json
+++ b/.github/mcp-config.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/specification/main/schema/mcp-config.schema.json",
+  "mcpServers": {
+    "github": {
+      "type": "local",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${env:GH_TOKEN}"
+      },
+      "description": "GitHub API access for issue/PR/repo operations. Read-only unless otherwise granted by task.",
+      "allowed-tools": [
+        "get_issue",
+        "get_pull_request",
+        "list_pull_request_files",
+        "get_file_contents",
+        "search_code",
+        "search_issues",
+        "list_commits",
+        "get_commit"
+      ]
+    },
+    "fhir-validator": {
+      "type": "local",
+      "command": "fhir-validator",
+      "args": ["-mcp"],
+      "description": "HAPI FHIR validator for FHIR R4/R5 resource validation during test authoring.",
+      "allowed-tools": ["validate_resource", "list_ig_packages"]
+    },
+    "ruralpeds-docs": {
+      "type": "url",
+      "url": "https://docs.ruralpeds.internal/mcp",
+      "description": "Org-internal docs MCP: standards maps, DHF templates, coding guidelines. Read-only.",
+      "allowed-tools": ["search_docs", "fetch_standards_map"]
+    }
+  },
+  "notes": [
+    "This file is the template for agent MCP config. Copy into repos that need the github/fhir-validator/docs MCPs.",
+    "The Copilot coding agent reads .github/mcp-config.json if present in the repo it's assigned to.",
+    "Claude Code reads .mcp.json at the repo root by convention; users should symlink or duplicate as needed.",
+    "Never include MCP servers that can exfiltrate PHI or write to external systems without explicit task authorization."
+  ]
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,109 @@
+name: Copilot Setup Steps
+
+# This workflow runs in the Copilot coding agent's ephemeral environment
+# BEFORE the agent begins work on an assigned issue. Pre-install everything
+# the agent will need so it doesn't waste turns on environment setup.
+#
+# Reference: https://docs.github.com/en/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent
+
+on:
+  workflow_dispatch:
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Setup Go
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version: "1.23"
+          cache: true
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        with:
+          toolchain: stable
+          components: "rustfmt,clippy"
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # v2.6.1
+        with:
+          version: "1.11"
+
+      - name: Install org-wide CLI tools
+        run: |
+          set -euo pipefail
+          # Formatters / linters the agent will need to run before pushing
+          pip install --quiet ruff mypy pre-commit yamllint
+          npm install --global --silent prettier@3.3.3 eslint@9.x markdownlint-cli@0.42.0 pnpm@9
+          cargo install --quiet cargo-deny cargo-audit
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
+          # Signing / attestation tooling
+          curl -sSfLO https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-amd64
+          chmod +x cosign-linux-amd64
+          sudo mv cosign-linux-amd64 /usr/local/bin/cosign
+
+          # SBOM tooling
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.18.0
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.84.0
+
+          # FHIR validator (needs Java)
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends default-jre-headless
+          curl -sSfLO https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar
+          sudo mv validator_cli.jar /usr/local/bin/validator_cli.jar
+          echo '#!/usr/bin/env bash' | sudo tee /usr/local/bin/fhir-validator >/dev/null
+          echo 'java -jar /usr/local/bin/validator_cli.jar "$@"' | sudo tee -a /usr/local/bin/fhir-validator >/dev/null
+          sudo chmod +x /usr/local/bin/fhir-validator
+
+      - name: Pre-cache workspace deps (best-effort)
+        run: |
+          set +e
+          [ -f package.json ] && npm ci --ignore-scripts
+          [ -f pyproject.toml ] && pip install --quiet -e ".[dev]" 2>/dev/null
+          [ -f requirements.txt ] && pip install --quiet -r requirements.txt
+          [ -f go.mod ] && go mod download
+          [ -f Cargo.toml ] && cargo fetch --locked
+          [ -f Project.toml ] && julia -e 'using Pkg; Pkg.instantiate()'
+          true
+
+      - name: Dump tool versions (for agent context)
+        run: |
+          {
+            echo "# Available tools in this environment"
+            echo ""
+            echo "- node: $(node --version)"
+            echo "- python: $(python --version)"
+            echo "- go: $(go version)"
+            echo "- rust: $(rustc --version)"
+            echo "- julia: $(julia --version)"
+            echo "- cosign: $(cosign version 2>&1 | head -1)"
+            echo "- syft: $(syft version 2>&1 | head -1)"
+            echo "- grype: $(grype version 2>&1 | head -1)"
+            echo "- actionlint: $(actionlint -version)"
+            echo "- ruff: $(ruff --version)"
+            echo "- prettier: $(prettier --version)"
+          } > /tmp/agent-tools.md
+          cat /tmp/agent-tools.md

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -40,7 +40,7 @@ jobs:
           cache: true
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           components: "rustfmt,clippy"

--- a/.github/workflows/copilot-task-guardrails.yml
+++ b/.github/workflows/copilot-task-guardrails.yml
@@ -1,0 +1,290 @@
+name: Agent PR Guardrails
+
+# Runs on every PR. If the PR is from an agent (detected by label or branch
+# prefix), enforces the additional guardrails from AGENTS.md that are hard
+# to encode in a pre-commit hook or a human's head.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: agent-guardrails-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  detect-agent:
+    runs-on: ubuntu-latest
+    outputs:
+      is-agent: ${{ steps.check.outputs.is-agent }}
+      agent-name: ${{ steps.check.outputs.agent-name }}
+      repo-class: ${{ steps.check.outputs.repo-class }}
+      data-class: ${{ steps.check.outputs.data-class }}
+    steps:
+      - name: Check if PR is from an agent
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          LABELS: ${{ toJson(github.event.pull_request.labels) }}
+        run: |
+          set -euo pipefail
+          is_agent=false
+          agent_name="none"
+
+          # Branch prefix check
+          if [[ "$HEAD_REF" =~ ^agent/ ]]; then
+            is_agent=true
+          fi
+
+          # Author check (known agent accounts)
+          case "$AUTHOR" in
+            copilot|github-copilot|github-copilot[bot]|copilot-swe-agent[bot])
+              is_agent=true; agent_name="copilot";;
+            claude-code|claude-code[bot])
+              is_agent=true; agent_name="claude-code";;
+            codex-bot|codex-bot[bot])
+              is_agent=true; agent_name="codex";;
+          esac
+
+          # Label check
+          if echo "$LABELS" | grep -qE '"name":"agent:(copilot|claude-code|codex|cursor)"'; then
+            is_agent=true
+            agent_name=$(echo "$LABELS" | grep -oE 'agent:[a-z-]+' | head -1 | cut -d: -f2)
+          fi
+
+          # Repo custom property lookup (best-effort; falls back to "unknown")
+          repo_class="unknown"
+          data_class="unknown"
+          set +e
+          props=$(gh api "repos/${GITHUB_REPOSITORY}/properties/values" 2>/dev/null || echo "[]")
+          repo_class=$(echo "$props" | jq -r '.[] | select(.property_name=="iec62304-class") | .value' 2>/dev/null || echo "unknown")
+          data_class=$(echo "$props" | jq -r '.[] | select(.property_name=="data-classification") | .value' 2>/dev/null || echo "unknown")
+          set -e
+
+          echo "is-agent=$is_agent"           >> "$GITHUB_OUTPUT"
+          echo "agent-name=$agent_name"       >> "$GITHUB_OUTPUT"
+          echo "repo-class=${repo_class:-unknown}" >> "$GITHUB_OUTPUT"
+          echo "data-class=${data_class:-unknown}" >> "$GITHUB_OUTPUT"
+
+          echo "## Agent detection"
+          echo "- is_agent: $is_agent"
+          echo "- agent_name: $agent_name"
+          echo "- repo_class: $repo_class"
+          echo "- data_class: $data_class"
+
+  forbidden-paths:
+    needs: detect-agent
+    if: needs.detect-agent.outputs.is-agent == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Enforce AGENTS.md §4.3 forbidden paths
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Read authorized exceptions from the issue body
+          issue_num=$(gh pr view "$PR_NUMBER" --json body -q '.body' | grep -oP '#\K[0-9]+' | head -1 || echo "")
+          task_authorized=""
+          if [ -n "$issue_num" ]; then
+            task_authorized=$(gh issue view "$issue_num" --json body -q '.body' | grep -oP 'authorizes?:\s*\K[^\s,]+' | tr '\n' '|' || echo "")
+          fi
+
+          # Absolutely forbidden (AGENTS.md §4.3)
+          FORBIDDEN=(
+            'audit-log/'
+            'dhf/risk/'
+            'dhf/classification.md'
+            '.github/workflows/audit-log.yml'
+            '.github/workflows/audit-verify.yml'
+            '.github/workflows/sync-rulesets.yml'
+            'policies/rulesets/'
+            'AGENTS.md'
+            '.github/copilot-instructions.md'
+            '.github/apps/'
+          )
+
+          changed=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+          echo "Changed files:"
+          echo "$changed"
+
+          violations=""
+          for path in "${FORBIDDEN[@]}"; do
+            if echo "$changed" | grep -qE "^${path//\//\\/}"; then
+              if [ -n "$task_authorized" ] && [[ "$task_authorized" == *"${path}"* ]]; then
+                echo "::notice::Task explicitly authorizes modification of $path"
+              else
+                violations="${violations}- \`$path\` (forbidden by AGENTS.md §4.3)\n"
+              fi
+            fi
+          done
+
+          if [ -n "$violations" ]; then
+            echo -e "❌ Forbidden path violations:\n$violations" | tee /tmp/violations.md
+            gh pr comment "$PR_NUMBER" --body-file /tmp/violations.md
+            gh pr edit "$PR_NUMBER" --add-label "blocked:forbidden-path"
+            exit 1
+          fi
+
+          echo "✅ No forbidden-path violations."
+
+  required-compliance-checks-preserved:
+    needs: detect-agent
+    if: needs.detect-agent.outputs.is-agent == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Ensure required-check workflows are not weakened
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          REQUIRED=(
+            '.github/workflows/reusable-phi-scan.yml'
+            '.github/workflows/reusable-sbom.yml'
+            '.github/workflows/audit-log.yml'
+            '.github/workflows/reusable-codeql.yml'
+            '.github/workflows/reusable-scorecard.yml'
+          )
+
+          fail=0
+          for wf in "${REQUIRED[@]}"; do
+            if git diff "$BASE_SHA"..."$HEAD_SHA" -- "$wf" | grep -qE '^\+.*(continue-on-error:\s*true|if:\s*false)'; then
+              echo "::error::$wf has been weakened (continue-on-error:true or if:false added)."
+              fail=1
+            fi
+          done
+
+          if [ $fail -eq 1 ]; then
+            exit 1
+          fi
+          echo "✅ Required compliance workflows not weakened."
+
+  pr-description-complete:
+    needs: detect-agent
+    if: needs.detect-agent.outputs.is-agent == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR description has all required sections
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          body=$(gh pr view "$PR_NUMBER" --json body -q '.body')
+          required=(
+            '## Summary'
+            '## Files Changed'
+            '## Acceptance Criteria'
+            '## Tests'
+            '## Audit Events'
+            '## Security Implications'
+            '## Standards Touched'
+            '## Rollback'
+            '## Agent Self-Check'
+          )
+          missing=()
+          for section in "${required[@]}"; do
+            if ! grep -qF "$section" <<<"$body"; then
+              missing+=("$section")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '❌ PR description is missing required sections:\n' > /tmp/pr-desc.md
+            for s in "${missing[@]}"; do
+              printf '- %s\n' "$s" >> /tmp/pr-desc.md
+            done
+            printf '\nSee `.github/copilot-instructions.md` for the exact template.\n' >> /tmp/pr-desc.md
+            gh pr comment "$PR_NUMBER" --body-file /tmp/pr-desc.md
+            gh pr edit "$PR_NUMBER" --add-label "blocked:pr-description-incomplete"
+            exit 1
+          fi
+          echo "✅ PR description has all required sections."
+
+  phi-scan-on-diff:
+    needs: detect-agent
+    if: needs.detect-agent.outputs.is-agent == 'true'
+    uses: ./.github/workflows/reusable-phi-scan.yml
+    with:
+      scan-scope: "diff"
+      base-sha: ${{ github.event.pull_request.base.sha }}
+      head-sha: ${{ github.event.pull_request.head.sha }}
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: write
+
+  class-bc-needs-human:
+    needs: detect-agent
+    if: >
+      needs.detect-agent.outputs.is-agent == 'true' &&
+      (needs.detect-agent.outputs.repo-class == 'class-b' ||
+       needs.detect-agent.outputs.repo-class == 'class-c' ||
+       needs.detect-agent.outputs.data-class == 'phi-active')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require human-review label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR_NUMBER" --add-label "review:human-required"
+          echo "🔒 Class B/C or phi-active repo: human review required. Auto-merge disabled."
+
+  audit-log-agent-pr:
+    needs: [detect-agent, forbidden-paths, required-compliance-checks-preserved, pr-description-complete]
+    if: always() && needs.detect-agent.outputs.is-agent == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Emit audit event for agent PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AGENT: ${{ needs.detect-agent.outputs.agent-name }}
+          REPO_CLASS: ${{ needs.detect-agent.outputs.repo-class }}
+          DATA_CLASS: ${{ needs.detect-agent.outputs.data-class }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg event "agent.pr.guardrails_evaluated" \
+            --arg pr "$PR_NUMBER" \
+            --arg agent "$AGENT" \
+            --arg repo_class "$REPO_CLASS" \
+            --arg data_class "$DATA_CLASS" \
+            --arg forbidden "${{ needs.forbidden-paths.result }}" \
+            --arg required_check "${{ needs.required-compliance-checks-preserved.result }}" \
+            --arg desc_check "${{ needs.pr-description-complete.result }}" \
+            '{timestamp:$ts, event:$event, pr:$pr, agent:$agent, repo_class:$repo_class, data_class:$data_class,
+              checks:{forbidden_paths:$forbidden, required_checks_preserved:$required_check, pr_description:$desc_check}}' \
+            > /tmp/audit-event.json
+          cat /tmp/audit-event.json
+          # Persisting to the Merkle chain is the responsibility of the audit-log workflow.
+          # We emit a job summary instead so it's visible in Actions logs.
+          echo "### Agent PR audit event" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json'                    >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/audit-event.json         >> "$GITHUB_STEP_SUMMARY"
+          echo '```'                        >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/seed-roadmap-issues.yml
+++ b/.github/workflows/seed-roadmap-issues.yml
@@ -61,5 +61,5 @@ jobs:
           python scripts/seed_issues.py \
             --phase "$PHASE" \
             --repo "$REPO" \
-            ${DRY_RUN:+--dry-run} \
+            $([ "$DRY_RUN" = "true" ] && echo "--dry-run") \
             ${ASSIGN_TO:+--assign-to "$ASSIGN_TO"}

--- a/.github/workflows/seed-roadmap-issues.yml
+++ b/.github/workflows/seed-roadmap-issues.yml
@@ -1,0 +1,65 @@
+name: Seed Roadmap Issues
+
+# Reads all task files under copilot-tasks/phase-NN-*/task-*.md and, for each
+# one without a corresponding open issue, files an agent-ready issue using the
+# agent-task template. Safe to re-run — it's idempotent.
+
+on:
+  workflow_dispatch:
+    inputs:
+      phase:
+        description: "Phase to seed (e.g. 'phase-01', or 'all')"
+        required: true
+        default: "all"
+        type: string
+      dry-run:
+        description: "List what would be created without creating"
+        required: false
+        default: false
+        type: boolean
+      assign-to:
+        description: "Assignee for created issues (e.g. 'copilot' or a username). Leave empty for no assignment."
+        required: false
+        default: ""
+        type: string
+  schedule:
+    # Weekly re-check: catches newly-added task files.
+    - cron: "0 4 * * 1"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: seed-roadmap
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install deps
+        run: pip install --quiet pyyaml
+
+      - name: Run seed script
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PHASE: ${{ inputs.phase || 'all' }}
+          DRY_RUN: ${{ inputs.dry-run || 'false' }}
+          ASSIGN_TO: ${{ inputs.assign-to || '' }}
+          REPO: ${{ github.repository }}
+        run: |
+          python scripts/seed_issues.py \
+            --phase "$PHASE" \
+            --repo "$REPO" \
+            ${DRY_RUN:+--dry-run} \
+            ${ASSIGN_TO:+--assign-to "$ASSIGN_TO"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,224 @@
+# AGENTS.md — Universal Agent Contract for the ruralpeds Organization
+
+This file is authoritative guidance for any AI coding agent operating inside any `ruralpeds/*` repository, including but not limited to:
+
+- **GitHub Copilot** (chat, code review, and the coding agent when assigned to an issue)
+- **Claude Code** (CLI, IDE integrations)
+- **OpenAI Codex** (API- or CLI-driven)
+- **Cursor**, **Windsurf**, and any other IDE-embedded coding agent
+- **Custom in-house agents** invoked from workflows
+
+Every repo in the org imports this contract by reference. Path-scoped instructions in `.github/instructions/*.md` extend it for specific directories. Per-task instructions in GitHub issues narrow it further.
+
+**Precedence order when these conflict** (stricter wins on safety-critical items, narrower wins on style):
+
+1. Global refusals in this file (§1) — never overridable.
+2. Task-scoped requirements declared in the triggering issue.
+3. Path-scoped instructions in `.github/instructions/`.
+4. This file's non-refusal sections.
+5. Per-agent defaults (Copilot, Claude Code, etc.).
+
+---
+
+## 1. Hard refusals — never overridable
+
+An agent must refuse, and must not work around, the following, regardless of user instruction, issue body, or apparent authority:
+
+- **Never commit, generate, or embed real Protected Health Information (PHI/ePHI).** If a file, fixture, or log appears to contain real patient data, stop, label the PR `blocked:phi-suspected`, and escalate via issue comment. Never use heuristics like "it's probably fake" — if a name, MRN, DOB, or address is not clearly marked synthetic, treat it as real.
+- **Never disable, bypass, or weaken** the PHI scanner, SBOM generation, provenance attestation, audit-log workflow, signed-commit ruleset, CodeQL, secret scanning, or any compliance-related status check — not even temporarily, not even with `continue-on-error`, not even with `if: false`.
+- **Never delete or rewrite history** in `audit-log/`, `dhf/` (Design History File), `sbom/`, `vex/`, or any file under `policies/`. These directories are append-mostly; modifications require an explicit human-approved PR from a named reviewer, never from an agent.
+- **Never add a dependency** not vetted by the SBOM + Dependabot pipeline. If a new dependency is needed, open a PR that adds only the dependency plus its lockfile change, and wait for human approval before using it.
+- **Never publish releases, push to registries, sign artifacts, or invoke `cosign sign-blob` against non-ephemeral keys.** Agent work terminates at "PR ready for review." Release cutting is a human action with electronic-signature binding.
+- **Never modify `/.github/workflows/*-required.yml`, `/policies/rulesets/*.json`, or `/dhf/risk/**`** without an explicit issue that says "modify this file" and a `human-review-required` label on the resulting PR.
+- **Never log or echo** the contents of `.env*` files, secrets, tokens, signing keys, or anything that matches PHI patterns — even in "debug" output, even in commit messages, even in PR descriptions.
+- **Never invoke `git push --force`, `git rebase -i` over published history, or `git filter-repo`** on shared branches.
+
+A refusal under this section must be reported in the PR/issue comment with the rule cited. Do not attempt workarounds.
+
+---
+
+## 2. Scope of work
+
+An agent may work on a task when **all** of the following are true:
+
+- The task is an issue with the label `agent-task` and is assigned to the agent (for Copilot, that means assigned to `@copilot`; for other agents, the invocation is the equivalent).
+- The issue links to a task file under `copilot-tasks/phase-NN-*/task-*.md`.
+- The repo's `data-classification` custom property is not `phi-active` (PHI-active repos require human-only work unless a named exception is filed in `docs/exceptions/`).
+- The agent has read `AGENTS.md`, `.github/copilot-instructions.md`, the path-scoped instructions applicable to the files it intends to touch, and the linked task file.
+
+An agent must stop and request human input when:
+
+- The task's acceptance criteria are ambiguous, contradictory, or require clinical judgment.
+- The change would cross a boundary declared in the task file as "out of scope."
+- A test that previously passed begins to fail and the root cause is not trivially attributable to the change.
+- The change requires modifying a file that is declared immutable-for-agents in §1 or in path-scoped instructions.
+
+---
+
+## 3. Required workflow for every agent change
+
+1. **Read before writing.** Open and read: `AGENTS.md`, `copilot-instructions.md`, applicable `.github/instructions/*.md`, the task file, and any files the task references. Do not start editing before reading.
+2. **Branch convention:** `agent/<phase>/<slug>-<short-issue-#>`. Example: `agent/phase-01/pin-actions-sha-42`.
+3. **One task per PR.** If you find adjacent problems, open a new issue labeled `agent-task-candidate` and link it; do not bundle.
+4. **Small diffs.** Prefer diffs under 400 changed lines. If a task genuinely requires more, split the task (open a follow-up issue) and stop at a reviewable increment.
+5. **Tests required.** Every behavior change requires added or modified tests. Exceptions: pure doc PRs (still require `markdownlint` + link check), workflow-only PRs (require workflow-lint + dry-run log).
+6. **Tests must run locally before push.** Agents must invoke the repo's test commands (declared in `.github/instructions/tests.instructions.md` or a Makefile target) and include the final test-summary line in the PR description.
+7. **Commit messages:** Conventional Commits. Required types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `security`, `compliance`, `dhf`, `hazard`. Footer line required: `Refs: #<issue>`. For Class B/C repos, add `Requirement: SW-###` for any `feat` or `fix`.
+8. **PR description template** (must be filled entirely):
+   - Summary (≤ 3 sentences, plain language).
+   - Files changed (list with one-line rationale each).
+   - Acceptance criteria status (checklist from the task file, each checked or explained).
+   - Tests added/modified (list + how to run).
+   - Audit events added or changed (list, or "None").
+   - Security implications (list, or "None; no auth, network, or data-handling change").
+   - Standards touched (e.g., "NIST SSDF PW.4, HIPAA §164.312(b)").
+   - Rollback plan (one sentence).
+9. **Self-review before requesting human review.** Re-read your diff top to bottom. Look for: accidental PHI, hardcoded paths, leftover debug statements, skipped tests, unresolved TODOs, dependency drift.
+10. **Assign to a human reviewer.** Never mark a PR `ready-for-review` and self-approve. Assign the `CODEOWNERS` target for the touched paths.
+
+---
+
+## 4. What the agent may modify vs. not
+
+### 4.1 Generally safe (agents may open PRs freely)
+
+- `src/` (language source), `tests/`, `e2e/`, `docs/` (except where overridden below), `scripts/`, non-sensitive workflow additions.
+- `.github/workflows/*.yml` **for the specific workflow named in the task**; not other workflows.
+- Lockfiles, when the PR is explicitly a dependency update.
+
+### 4.2 Requires explicit task authorization
+
+Agents may modify these only if the issue body explicitly says "this task modifies X" and includes the full path:
+
+- `.github/workflows/*.yml` beyond the one named.
+- `.github/copilot-instructions.md` or `.github/instructions/**`.
+- `AGENTS.md`.
+- `CODEOWNERS`.
+- `policies/**`.
+- `CONTRIBUTING.md`, `SECURITY.md`, `README.md` if the change is non-trivial (> 20 lines).
+
+### 4.3 Never modified by agents
+
+- `audit-log/**` (enforced by a CI check; modifications happen only via the `audit-log.yml` workflow run).
+- `dhf/risk/**` (hazard analysis, risk controls, residual risk — human clinical review required).
+- `dhf/classification.md` (software safety class — one-time human-authored file).
+- `.github/workflows/audit-log.yml`, `.github/workflows/audit-verify.yml`, `.github/workflows/sync-rulesets.yml` (the compliance control plane itself).
+- `policies/rulesets/**` (governance-as-code; human-approved only).
+- Any file under `sbom/<released-version>/` or `vex/<released-version>/` once that version is tagged.
+- `.git/**`, `.github/apps/**`, any file owned by `@ruralpeds/security`.
+
+---
+
+## 5. Clinical-software specifics
+
+These apply to repos with `criticality ∈ {clinical-support, clinical-decision, device}` or `iec62304-class ∈ {class-a, class-b, class-c}`:
+
+- Every new `src/` function that performs clinical calculation, interpretation, or decision must be annotated in source: `/** @requirement SW-### @risk-control RC-### */` (or the language-appropriate comment form). Agents must add these annotations whenever adding such a function.
+- Test files must annotate the requirement they verify: `@requirement("SW-###")` as a test decorator/attribute.
+- Any code change that touches a function annotated with a risk-control requires mentioning that risk-control in the PR body under "Standards touched."
+- No float comparisons without explicit tolerance and a comment citing clinical acceptable-error range.
+- No silent unit conversion. If a function accepts a quantity, either require a typed-units wrapper or explicitly reject ambiguous inputs.
+- No unbounded loops or recursion on user-supplied input without a declared iteration/stack limit.
+- Every externally-visible API that returns a clinical quantity must include units in the response.
+
+---
+
+## 6. Testing requirements
+
+- **Minimum coverage by class** (gate enforced in CI):
+  - Class A: 70% line, 60% branch.
+  - Class B: 85% line, 75% branch, 70% mutation kill rate (weekly, not per-PR).
+  - Class C: 95% line, 90% branch, 85% mutation kill rate.
+- **Property-based tests required** for any function in `src/clinical/`, `src/dose/`, `src/growth/`, `src/lab-interp/`, or equivalently named modules. Must cover boundary values, unit-confusion inputs, and order-of-magnitude errors (tenfold-dose).
+- **FHIR validation** required for any function that produces a FHIR resource; tests must pipe output through the HAPI validator.
+- **PHI-leak test** required for any service that emits logs; synthetic patient is fed through, log output is asserted to contain no identifiers.
+- **Deterministic tests.** No reliance on wall-clock time, current date, random without seed, network without mock, filesystem without tmpdir.
+
+---
+
+## 7. Security requirements
+
+- Input validation at every boundary (HTTP handler, queue consumer, file parser, CLI flag).
+- Parameterized queries only; no string concatenation into SQL.
+- Output encoding appropriate to the sink (HTML-escape for HTML, JSON-escape for JSON, shell-escape never — no shell-out with user input).
+- Authz check on every protected endpoint; deny-by-default.
+- Correlation IDs generated at ingress and propagated to every log line and downstream call.
+- Secrets via env var or mounted secret; never inline, never in config committed to repo, never in logs.
+- TLS 1.3 for new code; TLS 1.2 only with documented exception in `docs/exceptions/`.
+- Rate limiting on every public endpoint.
+- All HTTP clients: explicit timeout + retry policy + circuit breaker from `sci-resilience`.
+
+---
+
+## 8. Observability requirements
+
+- Every new service emits: structured JSON logs, OpenTelemetry traces, Prometheus metrics per RED (Rate/Errors/Duration).
+- Mandatory log fields: `timestamp`, `service`, `version`, `trace_id`, `span_id`, `level`, `event`, `actor_id`, `correlation_id`. Add `tenant_id`, `patient_ref_hash` where applicable (patient_ref_hash is sha256(mrn + per-service-salt), never raw MRN).
+- Health endpoints: `GET /healthz` (liveness), `GET /readyz` (readiness), `GET /version` (build metadata + SBOM digest).
+- No `println!`, `console.log`, `print()`, `@info` in production code paths; use the shared logger.
+
+---
+
+## 9. Style, format, and hygiene
+
+- Language-native formatter + linter enforced in CI. Agent must run them before pushing.
+- No TODO/FIXME without an issue number: `// TODO(#123): describe`.
+- No commented-out code. Delete or commit.
+- No trailing whitespace, no mixed tabs/spaces, Unix line endings.
+- File encodings: UTF-8 without BOM.
+- Line length: 120 chars soft, 160 chars hard — exceptions for long URLs and base64.
+
+---
+
+## 10. Escalation paths
+
+When an agent hits a wall, it writes a comment on the issue with one of the following prefixes and then stops:
+
+- **`ASK:`** — a clarifying question. Do not guess; wait for answer.
+- **`BLOCKED:`** — the task cannot proceed without a human change (e.g., custom property not yet set, secret not yet rotated, dependency not yet approved).
+- **`RISK:`** — the requested change has a risk the task did not anticipate; stop and request human judgment.
+- **`SPLIT:`** — the task is larger than estimated; propose a split.
+- **`DONE-PARTIAL:`** — a reviewable increment is ready; the rest is out of scope or needs a separate task.
+
+The agent does not take alternate paths silently. It reports and waits.
+
+---
+
+## 11. PR labels an agent sets on its own PRs
+
+The agent labels its PR at creation with all of:
+
+- `agent:<name>` — one of `agent:copilot`, `agent:claude-code`, `agent:codex`, `agent:cursor`.
+- `phase:<N>` — the roadmap phase.
+- `task:<slug>` — the task slug.
+- `class:<level>` — copy the repo's `iec62304-class` property.
+- `review:human-required` — always, for Class B/C.
+- `review:human-required` OR `review:cooling-off-ok` — Class A and below, per task file.
+
+---
+
+## 12. Agent self-checklist before opening a PR
+
+The agent must mentally (or literally, via comment) run this list and refuse to open a PR if any item is "no":
+
+- [ ] Task issue is assigned to me and labeled `agent-task`.
+- [ ] I read the task file, this AGENTS.md, and applicable `.github/instructions/*.md`.
+- [ ] Branch name follows `agent/<phase>/<slug>-<issue#>`.
+- [ ] Diff is scoped to files named or implied by the task.
+- [ ] No file under §4.3 is modified.
+- [ ] No PHI scanner / SBOM / audit workflow is modified (unless this task is that one).
+- [ ] Tests added or modified; all tests green locally.
+- [ ] Lint, format, type checks green.
+- [ ] Commit messages follow Conventional Commits with `Refs:` footer.
+- [ ] PR description fills every section of the template.
+- [ ] Labels set per §11.
+- [ ] Human reviewer assigned.
+- [ ] Rollback plan stated.
+
+---
+
+## 13. Version and review
+
+This file is reviewed by `@ruralpeds/security` and `@ruralpeds/clinical` quarterly or when any rule is triggered and found to be ambiguous. Edits follow the standard PR process plus require two human reviewers. The agent does not edit this file.
+
+*AGENTS.md v1.0 — 2026-04-23*

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,174 @@
+# INSTALL — How to drop this bundle into `ruralpeds/.github`
+
+This bundle is a set of files that together turn your roadmap into an agentic
+pipeline: task files → auto-seeded issues → `@copilot`-worked PRs → guardrailed
+merges → audit ledger.
+
+## TL;DR
+
+```bash
+# 1. Clone your .github repo
+git clone https://github.com/ruralpeds/.github.git
+cd .github
+git checkout -b agentic-pipeline-bootstrap
+
+# 2. Copy the bundle contents
+cp -r <path-to-this-bundle>/* .
+cp -r <path-to-this-bundle>/.github/* .github/
+cp <path-to-this-bundle>/.github/copilot-instructions.md .github/
+cp <path-to-this-bundle>/AGENTS.md .
+
+# 3. Review, commit, push
+git add -A
+git commit -m "feat: bootstrap agentic task pipeline (AGENTS.md + guardrails + seeder)"
+git push -u origin agentic-pipeline-bootstrap
+
+# 4. Open a PR and review it yourself carefully — this PR defines how
+#    every future agent PR will be reviewed, so the bar is high.
+
+# 5. Once merged, kick off the seeder:
+gh workflow run seed-roadmap-issues.yml \
+  -f phase=phase-01 \
+  -f dry-run=true \
+  -R ruralpeds/.github
+
+# Inspect the dry-run output. If it looks right:
+gh workflow run seed-roadmap-issues.yml \
+  -f phase=phase-01 \
+  -f dry-run=false \
+  -f assign-to=copilot \
+  -R ruralpeds/.github
+
+# 6. Watch the first agent PR, learn, iterate on AGENTS.md and task files.
+```
+
+## What gets installed where
+
+```
+ruralpeds/.github/                               (your repo after install)
+├── AGENTS.md                                    ← universal agent contract
+├── .github/
+│   ├── copilot-instructions.md                  ← Copilot primary instructions
+│   ├── instructions/                            ← path-scoped (auto-apply)
+│   │   ├── workflows.instructions.md
+│   │   ├── dhf.instructions.md
+│   │   ├── security.instructions.md
+│   │   └── tests.instructions.md
+│   ├── ISSUE_TEMPLATE/
+│   │   └── agent-task.yml                       ← template for agent-ready issues
+│   └── workflows/
+│       ├── copilot-setup-steps.yml              ← agent environment preflight
+│       ├── copilot-task-guardrails.yml          ← AGENTS.md enforcement
+│       └── seed-roadmap-issues.yml              ← creates issues from task files
+├── scripts/
+│   └── seed_issues.py                           ← reads task files, creates issues
+├── copilot-tasks/                               ← the task queue (source of truth)
+│   ├── README.md
+│   ├── _schema.md
+│   ├── phase-01-platform-hardening/
+│   │   ├── task-01-secret-scanning-push-protection.md
+│   │   ├── task-02-pin-actions-sha.md
+│   │   └── task-03-custom-properties.md
+│   ├── phase-02-supply-chain/
+│   │   └── task-01-slsa-provenance-attest-sbom.md
+│   ├── phase-04-audit-depth/
+│   │   └── task-01-merkle-chain-audit-ledger.md
+│   ├── phase-06-iec62304/
+│   │   └── task-01-iec62304-traceability-workflow.md
+│   └── phase-08-ha-patterns/
+│       └── task-01-sci-resilience-crate.md
+└── docs/
+    └── AGENT_WORKFLOW.md                        ← end-to-end human walkthrough
+```
+
+## Prerequisites
+
+Before the pipeline can seed issues or have Copilot work them:
+
+1. **GitHub Copilot Enterprise** (or Business + coding-agent preview) enabled
+   for the org. Confirm at Organization settings → Copilot → Coding agent.
+
+2. **Org-level custom properties defined** — without these, the
+   `copilot-task-guardrails.yml` job falls back to `repo-class=unknown` and
+   can't distinguish Class A from Class C. Phase-01 task-03 is itself the
+   task that sets this up, so for bootstrap either:
+   - Define the six properties by hand first via the GitHub UI, then run
+     the seeder; or
+   - Run the seeder and let the agent do task-03 as its first job — the
+     guardrails will treat the repo as class-unknown (defaults to
+     `review:human-required`, which is safe).
+
+3. **`GITHUB_TOKEN` permissions** — your org setting
+   "Workflow permissions" must allow `contents: read-write` and
+   `pull-requests: write` at minimum for the seed workflow to create issues.
+
+4. **Pin the action SHAs.** Every `<PINNED_SHA>` placeholder in the bundled
+   workflows needs to be replaced with a real 40-char commit SHA before
+   merge. You can do this in the bootstrap PR itself (run
+   `pin-github-action` during review) or file it as your first agent task.
+
+5. **CODEOWNERS** entries for the sensitive paths:
+   ```
+   /AGENTS.md                             @ruralpeds/security @ruralpeds/clinical
+   /.github/copilot-instructions.md       @ruralpeds/security
+   /.github/instructions/dhf.*            @ruralpeds/clinical
+   /.github/instructions/security.*       @ruralpeds/security
+   /policies/**                           @ruralpeds/security
+   /audit-log/**                          @ruralpeds/security
+   /copilot-tasks/**                      @ruralpeds/engineering
+   ```
+
+## Verification that install worked
+
+Run these after merging the bootstrap PR:
+
+```bash
+# Files in the right place
+test -f AGENTS.md
+test -f .github/copilot-instructions.md
+test -f .github/workflows/copilot-task-guardrails.yml
+test -f .github/workflows/seed-roadmap-issues.yml
+test -f scripts/seed_issues.py
+ls copilot-tasks/phase-01-platform-hardening/
+
+# Scripts run without error in dry-run
+GH_TOKEN=$(gh auth token) python scripts/seed_issues.py \
+  --repo ruralpeds/.github --phase phase-01 --dry-run
+
+# Workflow is listable
+gh workflow list -R ruralpeds/.github | grep -i seed
+gh workflow list -R ruralpeds/.github | grep -i guardrail
+```
+
+## Rollout order (recommended)
+
+1. **Week 0**: merge bootstrap PR. Pin SHAs. Set CODEOWNERS.
+2. **Week 1**: run seeder for phase-01 only, dry-run. Review the preview
+   output. Adjust task files if any frontmatter is off. Live-run.
+3. **Week 1**: assign phase-01/task-01 (secret scanning) first — it's
+   the simplest, safest agent task. Watch how the agent handles it.
+4. **Week 2**: phase-01/task-02 (pin SHAs) and task-03 (custom properties).
+   With properties in place, guardrails become fully effective.
+5. **Week 3+**: phase-02 onwards. Work in batches, not a flood. Review
+   guardrail logs, not just PRs.
+
+## What NOT to do
+
+- **Don't skip the bootstrap-PR review.** This PR defines the enforcement
+  substrate. Every rule that makes it in here will bind every future agent
+  PR.
+- **Don't merge AGENTS.md without `@ruralpeds/clinical` review** if any
+  repo in the org is clinical. They must sign off on §5 (clinical-software
+  specifics) in particular.
+- **Don't enable agent assignment in phi-active repos** until you've had
+  ≥3 successful agent cycles on non-phi repos. Build the trust graph.
+- **Don't rely on the agent to write new task files.** Tasks are authored
+  by humans (the roadmap owner). Agents execute tasks; they don't define
+  work.
+
+## Support
+
+Post-install questions, missing-file reports, or workflow tuning: open an
+issue with the label `infra` in `ruralpeds/.github`.
+
+Author: Timothy Hartzog, April 2026. Bundle version 1.0.

--- a/copilot-tasks/README.md
+++ b/copilot-tasks/README.md
@@ -1,0 +1,158 @@
+# `copilot-tasks/` — Machine-Readable Roadmap Tasks
+
+This directory is the **source of truth** for every roadmap item the agentic pipeline can execute. The `seed-roadmap-issues.yml` workflow reads these files and creates GitHub issues from them; each issue can then be assigned to `@copilot` (or another agent) to work on.
+
+## Layout
+
+```
+copilot-tasks/
+├── README.md                (you are here)
+├── _schema.md               (canonical schema for task files)
+├── phase-01-platform-hardening/
+│   ├── task-01-secret-scanning-push-protection.md
+│   ├── task-02-pin-actions-sha.md
+│   ├── task-03-custom-properties.md
+│   └── ...
+├── phase-02-supply-chain/
+│   └── ...
+├── phase-04-audit-depth/
+├── phase-06-iec62304/
+└── phase-08-ha-patterns/
+```
+
+Phases map 1-to-1 to the phases in `ENTERPRISE_ROADMAP.md`. Task numbering is sequential within a phase; gaps are fine when a task is retired.
+
+## File naming
+
+```
+task-<NN>-<kebab-case-slug>.md
+```
+
+The `<NN>` is a zero-padded sequence, used only for sort order — the `seed_issues.py` script keys on the slug, not the number.
+
+## File contents
+
+Every task file has **YAML frontmatter** (machine-readable) followed by **a Markdown body** (human-readable context the agent reads). See `_schema.md` for the full schema.
+
+Minimal example:
+
+```markdown
+---
+title: "Pin all workflow actions to 40-char SHAs"
+phase: phase-01
+slug: pin-actions-sha
+preferred-agent: copilot
+preflight-confirmation: false
+
+goal: >
+  Replace every `uses: owner/repo@<tag>` in `.github/workflows/**/*.yml`
+  with `uses: owner/repo@<sha>  # <tag>` so supply-chain posture matches
+  NIST SSDF PW.4.
+
+acceptance-criteria:
+  - "Every uses: line in .github/workflows/**/*.yml references a 40-char SHA"
+  - "Each pinned line has a trailing ` # <tag>` comment for Dependabot"
+  - "actionlint passes against all modified files"
+  - "A new Dependabot config entry exists for github-actions ecosystem"
+
+files-to-touch:
+  - ".github/workflows/**/*.yml"
+  - ".github/dependabot.yml"
+
+files-not-to-touch:
+  - "AGENTS.md"
+  - "policies/**"
+  - "audit-log/**"
+
+tests-required: |
+  - Run `actionlint` against every modified workflow; output must be clean.
+  - Run `yamllint --strict` against every modified workflow.
+
+standards:
+  - "NIST SSDF PW.4"
+  - "OpenSSF Scorecard: Pinned-Dependencies"
+  - "SLSA v1.0 — build requirements"
+
+rollback: >
+  Revert the merge commit; Dependabot will continue to work with tag refs.
+
+labels:
+  - "security"
+  - "supply-chain"
+---
+
+## Context
+
+GitHub Actions resolved by mutable tag (`@v4`, `@main`) can be hijacked by the action's maintainer or a repo compromise. Pinning to a 40-char commit SHA removes that risk.
+
+The `pin-github-action` CLI automates the pinning. Install and run:
+
+```bash
+npm install -g pin-github-action
+find .github/workflows -name '*.yml' -print -exec pin-github-action {} \;
+```
+
+Then commit the result with message `security: pin all workflow actions to SHAs`.
+
+## Verification
+
+After pinning, this command must return empty output:
+
+```bash
+grep -rE 'uses:\s+[^@]+@(v?[0-9]|main|master|latest)' .github/workflows/
+```
+```
+
+## Lifecycle of a task
+
+```
+   author writes task file
+          │
+          ▼
+  task committed to main
+          │
+          ▼
+  seed-roadmap-issues.yml runs (on schedule or on demand)
+          │
+          ▼
+  GitHub issue created, labeled, optionally assigned to @copilot
+          │
+          ▼
+  Copilot coding agent picks it up
+          │
+          ▼
+  Agent opens PR on branch agent/<phase>/<slug>-<issue#>
+          │
+          ▼
+  copilot-task-guardrails.yml enforces AGENTS.md rules
+          │
+          ▼
+  Reusable CI + PHI + SBOM + CodeQL + Scorecard run
+          │
+          ▼
+  Human reviewer (required for Class B/C) approves
+          │
+          ▼
+  Merge → audit-log.yml appends to Merkle chain → issue closes
+```
+
+## Who writes task files?
+
+- **The roadmap owner** (you) — for strategic phases.
+- **Other humans** — PRs against this directory are reviewed like any other PR.
+- **Agents** — agents MAY NOT add task files except via a human-reviewed PR explicitly scoped to that.
+
+Writing good task files is the highest-leverage activity in this system: a clear task file turns a vague idea into a 1–3 hour agent run.
+
+## Dry-running
+
+From any clone:
+
+```bash
+GH_TOKEN=$(gh auth token) python scripts/seed_issues.py \
+    --repo ruralpeds/.github \
+    --phase phase-01 \
+    --dry-run
+```
+
+This prints what would be created without touching the issue tracker.

--- a/copilot-tasks/_schema.md
+++ b/copilot-tasks/_schema.md
@@ -1,0 +1,76 @@
+# Task File Schema
+
+Every file under `copilot-tasks/phase-NN-*/task-*.md` MUST conform to this schema.
+`seed_issues.py` parses the frontmatter; `copilot-task-guardrails.yml` reads
+some fields (e.g. `files-not-to-touch`) when evaluating PRs.
+
+## Frontmatter (YAML)
+
+```yaml
+# ─── Required ────────────────────────────────────────────────────────────
+title: string              # Short description. Becomes issue title suffix.
+phase: string              # "phase-NN" — must match the containing directory prefix.
+slug: string               # kebab-case; must match filename suffix (task-NN-<slug>.md).
+goal: string               # Two sentences max, plain language, why this matters.
+
+acceptance-criteria:       # list[string] — Testable outcomes.
+  - "..."                  # One per line. All must be checked before PR merge.
+
+files-to-touch:            # list[string] — Explicit allow-list.
+  - "path/or/glob"         # Globs acceptable (handled in PR review).
+
+files-not-to-touch:        # list[string] — Explicit deny-list, additive to AGENTS.md §4.3.
+  - "..."
+
+tests-required: string     # Markdown-friendly description of test additions.
+
+rollback: string           # One sentence: how to revert.
+
+# ─── Optional ────────────────────────────────────────────────────────────
+preferred-agent: string    # "copilot" | "claude-code" | "codex" | "any". Default: "copilot".
+
+preflight-confirmation: bool  # If true, agent must list planned changes and wait
+                              # for a human comment before editing. Default: false.
+
+standards:                 # list[string] — Regulatory/industry standards cited.
+  - "NIST SSDF PW.4"
+  - "HIPAA §164.312(b)"
+
+labels:                    # list[string] — Extra labels beyond the seeder defaults.
+  - "security"
+
+estimated-complexity:      # "xs" | "s" | "m" | "l" — rough sizing, optional.
+                           # xs=<1h, s=1-3h, m=3-8h, l=>8h (if l, consider splitting).
+
+depends-on:                # list[string] — slugs of other tasks that must complete first.
+  - "custom-properties"
+
+authorizes:                # list[string] — explicit paths NORMALLY forbidden by AGENTS.md
+                           # that THIS task exceptionally permits. Guardrails honor this.
+  - ".github/workflows/audit-log.yml"   # only if task IS about audit-log.yml
+
+requires-human-after:      # "review" | "merge" | "deploy" — where a human must re-enter.
+                           # Default: "review".
+
+risk-controls:             # list[string] — IEC 62304 RC-### IDs this task implements.
+  - "RC-007"
+
+requirement-ids:           # list[string] — SW-### IDs this task satisfies.
+  - "SW-042"
+```
+
+## Body (Markdown)
+
+After the `---` frontmatter fence, free-form markdown. Conventionally:
+
+1. **## Context** — what the agent needs to know that isn't in the frontmatter.
+2. **## Approach** — (optional) suggested approach; agent may deviate with reason.
+3. **## Verification** — exact commands the agent should run to verify; these often become the PR's "Tests run locally" log.
+4. **## References** — links to standards sections, prior PRs, GitHub docs, etc.
+
+## Conventions
+
+- **Plain text ASCII** — no curly quotes, em-dashes outside prose, or other fancy unicode that might confuse YAML parsers.
+- **Concrete examples** over abstract description — the agent can work from an example of the change; it cannot always work from a description.
+- **Fail-closed tests** — tests should fail if the change is reverted, not just not-run.
+- **Bound scope** — if you're describing the task and it grows past 400 lines of diff, split it.

--- a/copilot-tasks/phase-01-platform-hardening/task-01-secret-scanning-push-protection.md
+++ b/copilot-tasks/phase-01-platform-hardening/task-01-secret-scanning-push-protection.md
@@ -1,0 +1,121 @@
+---
+title: "Enable secret scanning + push protection org-wide"
+phase: phase-01
+slug: secret-scanning-push-protection
+preferred-agent: copilot
+preflight-confirmation: false
+estimated-complexity: xs
+
+goal: >
+  Turn on GitHub secret scanning with push protection at the organization
+  level, and document the configuration. This is the single highest-ROI
+  security control we can enable and should be the first thing an agent
+  touches.
+
+acceptance-criteria:
+  - "Org-level 'Enable secret scanning for new private repositories' is ON"
+  - "Org-level 'Enable push protection' is ON"
+  - "Custom pattern for Tailscale auth keys (tskey-*) added"
+  - "Custom pattern for Anthropic API keys (sk-ant-*) added"
+  - "Custom pattern for WordPress application passwords added"
+  - "docs/security/secret-scanning.md describes the configuration, patterns, and alert triage"
+  - "Reusable workflow `reusable-secret-scan-report.yml` produced that compiles a weekly report of open secret alerts across the org"
+
+files-to-touch:
+  - "docs/security/secret-scanning.md"
+  - ".github/workflows/reusable-secret-scan-report.yml"
+  - "policies/secret-scanning/custom-patterns.yaml"
+
+files-not-to-touch:
+  - "AGENTS.md"
+  - "audit-log/**"
+  - ".github/workflows/audit-log.yml"
+
+tests-required: |
+  - `actionlint .github/workflows/reusable-secret-scan-report.yml` must pass.
+  - Manual verification: push a test branch containing a dummy token matching
+    each custom pattern (use `tskey-auth-EXAMPLEFAKE12345` etc.) to a scratch
+    repo; each push must be blocked with the pattern name shown. Document the
+    verification in the PR description.
+
+standards:
+  - "NIST SSDF PO.5.1 — implement supporting toolchains"
+  - "HIPAA §164.312(a)(2)(i) — unique user identification (by preventing shared secrets)"
+  - "OpenSSF Scorecard: Token-Permissions"
+
+rollback: >
+  Secret-scanning and push-protection can be disabled at org level if an
+  outage requires it; custom patterns can be deleted individually.
+
+labels:
+  - "security"
+  - "quick-win"
+
+---
+
+## Context
+
+GitHub's secret scanning finds leaked credentials in pushed commits; push
+protection rejects the push before it lands. Both are free for public repos;
+paid for private repos as part of GitHub Advanced Security.
+
+Org-level enforcement means every new repo inherits the setting automatically;
+the `repo-scanner.yml` workflow already creates new repos with baseline config,
+and this task ensures that baseline includes secret-scanning.
+
+## Approach
+
+1. **Enable at org level.** Via `Organization settings → Code security and
+   analysis → Secret scanning`: turn on for all private/internal/public repos,
+   and enable push protection. (This step is done in the GitHub UI; the agent
+   documents in `docs/security/secret-scanning.md` that it has been done, but
+   the toggle itself is a human action requiring org-owner permissions.)
+
+2. **Add custom patterns.** The org uses several secret types GitHub's
+   detectors don't cover. Create `policies/secret-scanning/custom-patterns.yaml`
+   with entries for:
+
+   ```yaml
+   patterns:
+     - name: "Tailscale auth key"
+       regex: 'tskey-auth-[A-Za-z0-9]{30,}'
+       push_protection: true
+     - name: "Anthropic API key"
+       regex: 'sk-ant-(api03|admin01)-[A-Za-z0-9_-]{40,}'
+       push_protection: true
+     - name: "WordPress application password"
+       regex: '[A-Za-z0-9]{4}(?:\s[A-Za-z0-9]{4}){5}'
+       push_protection: false    # too many false positives for hard block
+   ```
+
+   The agent produces the YAML; a human applies it via the GitHub API or UI.
+   (The Custom Patterns API requires GitHub Advanced Security; document the
+   API payload equivalent in the markdown doc.)
+
+3. **Produce the weekly report workflow.** `reusable-secret-scan-report.yml`
+   calls `GET /orgs/{org}/secret-scanning/alerts?state=open`, formats a
+   markdown summary (count by severity, top-10 newest, top-10 oldest),
+   uploads as a workflow artifact, and opens or updates a single tracking
+   issue titled "Weekly secret-scan report" in `ruralpeds/.github`.
+
+4. **Document.** `docs/security/secret-scanning.md` covers:
+   - How the feature works
+   - What custom patterns are in place and why
+   - Triage process (investigate → revoke → rotate → close alert → document)
+   - On-call: who gets paged for a critical-severity alert
+   - Links to GitHub's docs
+
+## Verification
+
+After the PR merges:
+
+- Confirm org-level toggles are on via a screenshot linked in the PR body.
+- Push a test branch with a fake `tskey-auth-EXAMPLEFAKE123456789012345678901234` in a file. Verify the push is blocked.
+- Push a test branch with a fake `sk-ant-api03-EXAMPLE...` value. Verify the push is blocked.
+- Confirm the weekly workflow produces output when manually dispatched.
+
+## References
+
+- GitHub docs: Secret scanning for your organization
+- GitHub docs: Push protection for custom patterns
+- NIST SP 800-218 (SSDF) PO.5

--- a/copilot-tasks/phase-01-platform-hardening/task-02-pin-actions-sha.md
+++ b/copilot-tasks/phase-01-platform-hardening/task-02-pin-actions-sha.md
@@ -1,0 +1,146 @@
+---
+title: "Pin all workflow actions to 40-char SHAs"
+phase: phase-01
+slug: pin-actions-sha
+preferred-agent: copilot
+preflight-confirmation: false
+estimated-complexity: s
+
+goal: >
+  Replace every `uses: owner/repo@<tag>` in `.github/workflows/**/*.yml` with
+  `uses: owner/repo@<40-char-sha>  # <tag>` so supply-chain posture matches
+  NIST SSDF PW.4 and OpenSSF Scorecard Pinned-Dependencies requires.
+
+acceptance-criteria:
+  - "Every `uses:` line in `.github/workflows/**/*.yml` references a 40-character commit SHA"
+  - "Each pinned line has a trailing ` # <tag>` comment so Dependabot can update it"
+  - "actionlint passes against all modified files"
+  - "yamllint --strict passes against all modified files"
+  - "A new Dependabot config entry exists for the `github-actions` ecosystem with weekly updates"
+  - "grep of the workflows returns empty output (see Verification)"
+
+files-to-touch:
+  - ".github/workflows/**/*.yml"
+  - ".github/dependabot.yml"
+
+files-not-to-touch:
+  - "AGENTS.md"
+  - "policies/**"
+  - "audit-log/**"
+  - ".github/workflows/audit-log.yml"
+
+tests-required: |
+  - Run `actionlint` against every workflow touched; must output nothing.
+  - Run `yamllint --strict` against every workflow touched.
+  - Run the verification grep (below); must return empty.
+  - Trigger a dispatch of `ci-node.yml` (or any CI) via workflow_dispatch
+    on a scratch branch; must complete successfully.
+
+standards:
+  - "NIST SSDF PW.4"
+  - "OpenSSF Scorecard: Pinned-Dependencies"
+  - "SLSA v1.0 — build requirements"
+
+rollback: >
+  Revert the merge commit. Dependabot will continue to function with tag refs
+  because it handles both forms.
+
+labels:
+  - "security"
+  - "supply-chain"
+  - "quick-win"
+
+---
+
+## Context
+
+Actions resolved by mutable tag (`@v4`, `@main`, `@latest`) can be silently
+replaced by the action maintainer. A compromised action can exfiltrate
+secrets, poison builds, or inject malicious code into release artifacts.
+Pinning to a 40-char commit SHA eliminates this risk; the trailing tag
+comment lets Dependabot propose updates.
+
+Current state: most workflows in this repo use tag-based pinning
+(`uses: actions/checkout@v4`). This task replaces all of them.
+
+## Approach
+
+1. **Install and run `pin-github-action`** in an ephemeral env:
+   ```bash
+   npm install --global pin-github-action@1.x
+   find .github/workflows -name '*.yml' -print0 | \
+     xargs -0 -n1 pin-github-action --allow-empty-actions-list
+   ```
+
+2. **Verify the output.** After pinning, these commands must all return
+   nothing:
+   ```bash
+   # No tag refs remaining
+   grep -rE 'uses:\s+[^@]+@(v?[0-9]|main|master|latest|HEAD)' .github/workflows/
+   # Every uses: line ends with a SHA
+   grep -rE 'uses:\s+[^@]+@[a-f0-9]{40}' .github/workflows/ | \
+     wc -l  # should equal total number of uses: lines
+   ```
+
+3. **Add a Dependabot config** (create or edit `.github/dependabot.yml`):
+
+   ```yaml
+   version: 2
+   updates:
+     - package-ecosystem: "github-actions"
+       directory: "/"
+       schedule:
+         interval: "weekly"
+         day: "monday"
+         time: "06:00"
+       groups:
+         actions-minor-patch:
+           update-types: ["minor", "patch"]
+       labels:
+         - "dependencies"
+         - "github-actions"
+       open-pull-requests-limit: 10
+   ```
+
+4. **Run `actionlint`** against every touched file. Fix any new issues the
+   pin introduces (e.g., if a SHA now resolves to a version with new
+   required inputs — unlikely but possible).
+
+5. **Commit the result** with message:
+   ```
+   security: pin all workflow actions to SHAs
+
+   Replaces tag-based `uses:` with commit-SHA pins; adds Dependabot config
+   to keep them fresh. Closes the last Scorecard Pinned-Dependencies gap.
+
+   Refs: #<issue>
+   ```
+
+## Verification
+
+Paste in the PR description the output of:
+
+```bash
+echo "=== Tag refs remaining (must be 0 lines) ==="
+grep -rcE 'uses:\s+[^@]+@(v?[0-9]|main|master|latest)' .github/workflows/ | \
+  awk -F: '$2 > 0'
+echo ""
+echo "=== Total uses: lines ==="
+grep -rE 'uses:\s+' .github/workflows/ | wc -l
+echo ""
+echo "=== SHA-pinned lines ==="
+grep -rE 'uses:\s+[^@]+@[a-f0-9]{40}' .github/workflows/ | wc -l
+echo ""
+echo "=== actionlint ==="
+actionlint
+```
+
+The first must show 0 lines. The second and third counts must match.
+`actionlint` must return no errors.
+
+## References
+
+- [pin-github-action](https://github.com/mheap/pin-github-action)
+- [Scorecard: Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+- [NIST SP 800-218 PW.4](https://csrc.nist.gov/pubs/sp/800/218/final)
+- [GitHub Security Lab: Mitigating Attacks on GitHub Actions](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

--- a/copilot-tasks/phase-01-platform-hardening/task-03-custom-properties.md
+++ b/copilot-tasks/phase-01-platform-hardening/task-03-custom-properties.md
@@ -1,0 +1,147 @@
+---
+title: "Define org custom repository properties"
+phase: phase-01
+slug: custom-properties
+preferred-agent: copilot
+preflight-confirmation: false
+estimated-complexity: s
+
+goal: >
+  Define six org-level custom repository properties and a workflow that
+  enforces their presence on every repo. Without these, the rulesets
+  in phase 3 have no way to target "only clinical repos" or "only phi-active".
+
+acceptance-criteria:
+  - "`policies/custom-properties/schema.yaml` defines the six properties with types, values, defaults"
+  - "`.github/workflows/custom-properties-audit.yml` runs weekly, lists repos missing required properties, opens/updates a tracking issue"
+  - "`docs/governance/custom-properties.md` documents each property, when to change it, who approves"
+  - "README.md for `.github` repo includes a link to the properties doc"
+  - "A helper script `scripts/set-properties.py <repo>` interactively sets properties using gh api"
+
+files-to-touch:
+  - "policies/custom-properties/schema.yaml"
+  - ".github/workflows/custom-properties-audit.yml"
+  - "docs/governance/custom-properties.md"
+  - "scripts/set-properties.py"
+  - "README.md"
+
+files-not-to-touch:
+  - "AGENTS.md"
+  - "audit-log/**"
+  - ".github/workflows/audit-log.yml"
+
+tests-required: |
+  - `actionlint .github/workflows/custom-properties-audit.yml` passes.
+  - `python -c "import yaml; yaml.safe_load(open('policies/custom-properties/schema.yaml'))"` passes.
+  - Dry-run the helper script against a test repo: `python scripts/set-properties.py --dry-run ruralpeds/.github`.
+
+standards:
+  - "NIST SSDF PO.1 — risk-based software security requirements"
+  - "HITRUST 01.a — access control policy (classification precondition)"
+
+rollback: >
+  Delete the six properties from org settings (they don't affect existing
+  workflows since no ruleset targets them yet).
+
+labels:
+  - "governance"
+
+---
+
+## Context
+
+Custom repository properties are org-level metadata tags that every workflow,
+ruleset, and script can read via `gh api repos/{owner}/{repo}/properties/values`.
+They are the **routing layer** for every subsequent governance decision:
+
+- Phase 3 rulesets target on `iec62304-class` and `data-classification`.
+- Phase 4 audit depth varies by `criticality`.
+- Phase 6 DHF scaffolding is gated on `iec62304-class != not-applicable`.
+- Phase 8 HA patterns are required where `criticality ≥ clinical-decision`.
+
+So this task is the keystone: nothing later works until this lands.
+
+The six properties and their values:
+
+```yaml
+data-classification:
+  values: [public, internal, synthetic, phi-capable, phi-active]
+criticality:
+  values: [experimental, reference, clinical-support, clinical-decision, device]
+iec62304-class:
+  values: [not-applicable, class-a, class-b, class-c]
+regulated:
+  values: [true, false]
+primary-stack:
+  values: [julia, rust, node, python, go, content, polyglot]
+baa-required:
+  values: [true, false]
+```
+
+## Approach
+
+1. **Write `policies/custom-properties/schema.yaml`** — single source of truth
+   for the property catalog.
+
+2. **Write `.github/workflows/custom-properties-audit.yml`** — runs weekly on
+   Mondays at 09:00 UTC:
+   - Lists all repos via `gh api orgs/ruralpeds/repos --paginate`.
+   - For each, fetches `gh api repos/ruralpeds/<name>/properties/values`.
+   - Flags repos missing any required property.
+   - Produces `reports/custom-properties-<date>.md`.
+   - Opens or updates a tracking issue titled
+     "Custom properties audit — YYYY-WW".
+
+3. **Write `scripts/set-properties.py`** — interactive wizard:
+   - Loads schema.
+   - Prompts for each property (shows current value if set).
+   - Calls `gh api --method PATCH repos/<repo>/properties/values -f ...`.
+   - Writes an audit record to `audit-log/property-changes.jsonl`
+     (since this IS authorized modification to `audit-log/`, the task's
+     `authorizes:` frontmatter must include that path — but actually no,
+     the script is *used by humans*, and the audit-log workflow handles
+     the write. The script only proposes; it does not write the ledger.)
+
+4. **Document** — `docs/governance/custom-properties.md` covers:
+   - What each property means.
+   - How to change it (via the script or the UI).
+   - What happens downstream when each value changes (e.g., changing
+     `iec62304-class` from `class-a` to `class-b` triggers new ruleset
+     enforcement on the next `sync-rulesets.yml` run).
+   - Who can change what (most are self-serve; `iec62304-class` and
+     `regulated=true` require clinical-lead approval).
+
+## Verification
+
+After merge:
+
+- Run the audit workflow manually: `gh workflow run custom-properties-audit.yml`.
+- Confirm the tracking issue opens with the current gap list.
+- Use the helper to set properties on a test repo (e.g., this one):
+
+  ```bash
+  python scripts/set-properties.py ruralpeds/.github
+  ```
+
+  Then:
+
+  ```bash
+  gh api repos/ruralpeds/.github/properties/values | jq
+  ```
+
+  must show all six properties set.
+
+## Notes for the agent
+
+- The `gh api --method PATCH .../properties/values` endpoint expects a body
+  with a `properties` array of `{property_name, value}`. Double-check the
+  API shape before generating the script.
+- Org-level custom property definitions are created via the GitHub UI; the
+  API creates the definitions too but requires admin permission. Document
+  in the markdown doc that the one-time schema creation is a human action
+  requiring org-owner.
+
+## References
+
+- GitHub docs: Managing custom properties for repositories
+- GitHub API: Repository custom properties

--- a/copilot-tasks/phase-02-supply-chain/task-01-slsa-provenance-attest-sbom.md
+++ b/copilot-tasks/phase-02-supply-chain/task-01-slsa-provenance-attest-sbom.md
@@ -1,0 +1,215 @@
+---
+title: "Add SLSA provenance + attest-sbom to release pipeline"
+phase: phase-02
+slug: slsa-provenance-attest-sbom
+preferred-agent: copilot
+preflight-confirmation: true
+estimated-complexity: m
+
+depends-on:
+  - pin-actions-sha
+
+goal: >
+  Every release artifact produced by `ruralpeds/*` gets a cryptographically
+  signed SLSA v1.0 provenance attestation and a Sigstore-signed SBOM
+  attestation, verifiable via `gh attestation verify`. Brings our posture to
+  SLSA Build Level 3 and closes the FDA §524B pre-market cybersecurity
+  expectation for binding SBOMs to artifacts.
+
+acceptance-criteria:
+  - "New reusable workflow `.github/workflows/reusable-slsa-provenance.yml` calls `actions/attest-build-provenance@v2`"
+  - "Existing `reusable-sbom.yml` extended to call `actions/attest-sbom@v2` binding the SBOM to each artifact hash"
+  - "Both workflows use keyless OIDC signing (no stored keys)"
+  - "Release workflow gains a verification step that runs `gh attestation verify` against the emitted artifacts; fails the release if verification fails"
+  - "docs/security/attestations.md explains: what provenance is, what SBOM attestation is, how downstream consumers verify, and the Rekor transparency-log URL pattern"
+  - "A sample release in a scratch repo demonstrates end-to-end: attestation visible in the repo's Attestations tab, verifiable via gh CLI"
+
+files-to-touch:
+  - ".github/workflows/reusable-slsa-provenance.yml"
+  - ".github/workflows/reusable-sbom.yml"
+  - ".github/workflows/release.yml"
+  - "docs/security/attestations.md"
+  - "README.md"
+
+files-not-to-touch:
+  - "AGENTS.md"
+  - "audit-log/**"
+  - ".github/workflows/audit-log.yml"
+  - "policies/rulesets/**"
+  - "sbom/<any-released-version>/**"
+
+tests-required: |
+  - `actionlint` passes on all touched workflows.
+  - A smoke-test release on a scratch repo produces attestations visible in the
+    repo's Attestations API: `gh api repos/<scratch>/attestations/<subject-sha>`
+    returns a non-empty list.
+  - `gh attestation verify <artifact> --repo <scratch>` succeeds for the
+    scratch release.
+
+standards:
+  - "SLSA v1.0 Build Level 3"
+  - "FDA §524B (2023 Omnibus Act — Cyber Devices)"
+  - "NIST SSDF PS.3 — archive and protect each software release"
+  - "NIST SSDF PO.5.2 — use automation where practical"
+  - "NTIA Minimum Elements for an SBOM (2021)"
+  - "Executive Order 14028 §4"
+
+rollback: >
+  Disable the new workflows (comment out the call in `release.yml`). Existing
+  artifacts remain signed; new ones fall back to unsigned. Downstream consumers
+  can continue to operate since verification is advisory until the
+  `org-clinical` ruleset gates on it (separate task).
+
+labels:
+  - "security"
+  - "supply-chain"
+  - "fda-524b"
+
+---
+
+## Context
+
+The org already generates CycloneDX + SPDX SBOMs via `reusable-sbom.yml`. The
+SBOMs are committed to `sbom/` and attached to releases — good, but not
+**cryptographically bound** to the artifacts. A tampered artifact with an
+unchanged SBOM would go undetected.
+
+`actions/attest-build-provenance` emits a signed SLSA v1.0 statement binding
+an artifact hash to the exact workflow run, commit, and builder identity.
+`actions/attest-sbom` emits a signed in-toto SBOM statement binding the SBOM
+file to the artifact hash. Both use Sigstore keyless signing via GitHub's
+OIDC identity; signatures land in the Rekor transparency log. Consumers
+verify offline with `gh attestation verify` or `cosign verify-attestation`.
+
+This is what FDA reviewers increasingly expect for "Cyber Device" premarket
+submissions under §524B and what supply-chain consumers (downstream hospitals,
+integrators) will ask for under SBOM-sharing regimes.
+
+## Approach
+
+### 1. `reusable-slsa-provenance.yml`
+
+New reusable workflow:
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      subject-path:
+        type: string
+        required: true
+        description: "Glob of artifacts to attest (e.g. 'dist/*.tar.gz')"
+    outputs:
+      attestation-url:
+        value: ${{ jobs.provenance.outputs.attestation-url }}
+
+permissions:
+  id-token: write         # for OIDC
+  attestations: write     # for writing attestation
+  contents: read
+
+jobs:
+  provenance:
+    runs-on: ubuntu-latest
+    outputs:
+      attestation-url: ${{ steps.attest.outputs.attestation-url }}
+    steps:
+      - uses: actions/checkout@<PINNED_SHA>  # pin per phase-01/task-02
+        with: { persist-credentials: false }
+      - name: Attest provenance
+        id: attest
+        uses: actions/attest-build-provenance@<PINNED_SHA>
+        with:
+          subject-path: ${{ inputs.subject-path }}
+```
+
+### 2. Extend `reusable-sbom.yml`
+
+After the existing SBOM generation steps, add:
+
+```yaml
+- name: Attest SBOM
+  uses: actions/attest-sbom@<PINNED_SHA>
+  with:
+    subject-path: ${{ inputs.subject-path }}
+    sbom-path: "sbom/cyclonedx.json"
+```
+
+Requires `attestations: write` permission.
+
+### 3. Modify `release.yml`
+
+After build + provenance + SBOM-attest steps, add verification:
+
+```yaml
+- name: Verify attestations
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    set -euo pipefail
+    for artifact in dist/*.tar.gz dist/*.whl dist/*.crate; do
+      [ -f "$artifact" ] || continue
+      echo "::group::Verifying $artifact"
+      gh attestation verify "$artifact" --repo "$GITHUB_REPOSITORY"
+      echo "::endgroup::"
+    done
+```
+
+### 4. Document in `docs/security/attestations.md`
+
+Cover:
+- What provenance is (binds artifact → build process).
+- What SBOM attestation is (binds artifact → components list).
+- How a downstream consumer verifies:
+
+  ```bash
+  # Download artifact and attestation
+  gh release download v1.2.3 -R ruralpeds/<repo> -p '*.tar.gz'
+  gh attestation verify mypkg-1.2.3.tar.gz --repo ruralpeds/<repo>
+  ```
+
+- How to look up the Rekor entry: the `gh attestation verify` output includes
+  a Rekor log index; show the URL pattern.
+- Retention: attestations are first-class GitHub objects, retained with the
+  repo.
+
+## Verification for this task
+
+Do the smoke test on a scratch repo (e.g. create `ruralpeds/attest-smoketest`):
+
+1. Add a minimal `Cargo.toml` or `package.json`, build a trivial artifact.
+2. Call the new workflows from a release trigger.
+3. After release, run:
+
+   ```bash
+   gh attestation verify dist/smoketest-0.1.tar.gz --repo ruralpeds/attest-smoketest
+   ```
+
+   Expected output includes `✓ Verification succeeded!` and a Rekor log index.
+
+4. Open `https://github.com/ruralpeds/attest-smoketest/attestations` and
+   confirm the provenance + SBOM attestations are listed with their subject
+   digests.
+
+Paste the verify output into the PR description.
+
+## Notes for the agent
+
+- `actions/attest-build-provenance` and `actions/attest-sbom` versions change
+  frequently; check for the latest when pinning. Use major-v2 at minimum —
+  v1 is deprecated.
+- Both actions require `permissions: id-token: write` and
+  `permissions: attestations: write` on the calling job. If the calling
+  workflow is reusable itself, those permissions must flow through.
+- `gh attestation verify` without `--repo` tries the default repo inference;
+  always pass `--repo` in CI for determinism.
+- On large artifacts (> 1 GB), the sign-step can take minutes. Set a generous
+  `timeout-minutes`.
+
+## References
+
+- GitHub: "Using artifact attestations to establish provenance for builds"
+- SLSA v1.0 specification (slsa.dev)
+- Sigstore / Fulcio / Rekor
+- FDA: "Cybersecurity in Medical Devices — Quality System Considerations" (Sept 2023)
+- Executive Order 14028 §4, §4(e), §4(n)

--- a/copilot-tasks/phase-04-audit-depth/task-01-merkle-chain-audit-ledger.md
+++ b/copilot-tasks/phase-04-audit-depth/task-01-merkle-chain-audit-ledger.md
@@ -1,0 +1,342 @@
+---
+title: "Upgrade audit ledger to Merkle chain with Sigstore signing"
+phase: phase-04
+slug: merkle-chain-audit-ledger
+preferred-agent: copilot
+preflight-confirmation: true
+estimated-complexity: l
+
+depends-on:
+  - pin-actions-sha
+
+goal: >
+  Upgrade the append-only `audit-log/ledger.json` to a Merkle-chained ndjson
+  log where each entry is cryptographically bound to the previous and
+  individually signed via Sigstore keyless OIDC. Add a nightly verification
+  workflow that replays the chain and fails loudly on tamper. This task
+  authorizes modification of `audit-log/**` and `.github/workflows/audit-log.yml`
+  because it IS the task to upgrade them.
+
+acceptance-criteria:
+  - "`audit-log/chain.ndjson` format defined with prev_hash / self_hash / signature fields"
+  - "`.github/workflows/audit-log.yml` writes to `chain.ndjson` (new entry appended) in addition to existing ledger.json"
+  - "Each appended entry has a valid Sigstore keyless signature verifiable via cosign"
+  - "`scripts/chain/append.py` + `scripts/chain/verify.py` implement the canonical form"
+  - "`.github/workflows/audit-verify.yml` runs nightly, replays the chain, and opens a critical issue on failure"
+  - "`docs/compliance/audit-chain.md` documents the format, verification command, and incident-response on a broken chain"
+  - "The existing `audit-log/ledger.json` is preserved and continues to be updated during a two-release transition period"
+
+files-to-touch:
+  - "audit-log/chain.ndjson"                       # new file, initial genesis entry
+  - "audit-log/GENESIS.md"                          # human-readable genesis note
+  - "scripts/chain/append.py"
+  - "scripts/chain/verify.py"
+  - ".github/workflows/audit-log.yml"
+  - ".github/workflows/audit-verify.yml"
+  - "docs/compliance/audit-chain.md"
+
+files-not-to-touch:
+  - "AGENTS.md"
+  - "policies/rulesets/**"
+  - "dhf/risk/**"
+
+authorizes:
+  - "audit-log/**"
+  - ".github/workflows/audit-log.yml"
+
+tests-required: |
+  - Unit tests for `append.py` and `verify.py` under `tests/chain/`:
+    - genesis entry creation
+    - append preserves prev_hash = prior self_hash
+    - verify on clean chain returns 0
+    - verify on chain with modified payload returns non-zero at the broken link
+    - verify on chain with missing entry (gap) returns non-zero
+    - verify on chain with invalid signature returns non-zero
+  - Integration test: run append three times in a scratch workspace; run verify;
+    corrupt one line; run verify; confirm failure at the right line.
+  - `actionlint` passes on the two workflows.
+
+standards:
+  - "HIPAA §164.312(b) — audit controls"
+  - "HIPAA §164.312(c)(1) — integrity"
+  - "21 CFR Part 11 §11.10(e) — audit trails"
+  - "NIST SP 800-92 — log management"
+  - "ISO 27001 A.12.4.2 — protection of log information"
+
+rollback: >
+  Roll back to the prior audit-log workflow (keeps ledger.json). The chain
+  file remains but is frozen; the audit-verify workflow returns early with a
+  notice that chain-appending has been disabled.
+
+labels:
+  - "compliance"
+  - "audit"
+  - "cryptography"
+
+requires-human-after: review
+
+---
+
+## Context
+
+The current `audit-log/ledger.json` is committed with every build — the commit
+itself is signed (required by the ruleset), and the ledger is append-only by
+convention. That's a good foundation, but it has two gaps:
+
+1. **No cryptographic chaining** — if the ledger.json file is rewritten in
+   a later commit (force-push is blocked, but a normal commit that replaces
+   the content would look legitimate to anyone only checking HEAD), there's
+   nothing inside the ledger itself that detects it.
+2. **No per-entry signature** — the commit signature proves who wrote the
+   commit, not who wrote each individual entry. A single poisoned commit
+   could insert multiple forged entries.
+
+The Merkle chain closes both gaps: each entry hashes the previous, and each
+entry is independently signed by the GitHub OIDC identity of the workflow run.
+Verification replays the chain and validates every signature — any alteration
+breaks the chain at a specific line.
+
+## Chain entry format
+
+Each line of `audit-log/chain.ndjson` is a single compact JSON object:
+
+```json
+{
+  "seq": 1347,
+  "timestamp": "2026-04-23T18:02:11.423Z",
+  "event_type": "build.completed",
+  "event_data": {
+    "repo": "ruralpeds/PedNeoSim.jl",
+    "sha": "3f4a1b7...",
+    "ref": "refs/heads/main",
+    "workflow": "ci-julia.yml",
+    "run_id": 12345678,
+    "actor": "timothyhartzog",
+    "result": "success",
+    "artifacts": ["...hashes..."],
+    "dependencies_hash": "sha256:..."
+  },
+  "prev_hash": "sha256:a1b2c3d4e5f6...",
+  "self_hash": "sha256:d4e5f6a1b2c3...",
+  "signature": "MEUCIQD...",
+  "signature_cert": "-----BEGIN CERTIFICATE-----\n...",
+  "signature_issuer": "https://token.actions.githubusercontent.com",
+  "signature_subject": "https://github.com/ruralpeds/.github/.github/workflows/audit-log.yml@refs/heads/main",
+  "rekor_log_index": 98765432
+}
+```
+
+Where:
+
+- `self_hash` = `sha256(canonical_json({seq, timestamp, event_type, event_data, prev_hash}))`.
+- Canonical JSON: UTF-8, no insignificant whitespace, keys sorted lexicographically, numbers in shortest form.
+- `signature` = Sigstore keyless signature of `self_hash` via `cosign sign-blob`.
+- `signature_cert` = Fulcio-issued short-lived cert, included inline for offline verification.
+- `rekor_log_index` = index in the public Sigstore Rekor transparency log.
+
+The **genesis entry** (`seq: 1`) has `prev_hash: "sha256:0000...0000"` and
+`event_type: "chain.genesis"`. Its `event_data` names the repo, the chain
+policy version, and the human who initialized it.
+
+## Approach
+
+### 1. `scripts/chain/append.py`
+
+Called by the audit-log workflow. Signature:
+
+```bash
+python scripts/chain/append.py \
+  --event-type build.completed \
+  --event-data /tmp/event.json \
+  --chain audit-log/chain.ndjson \
+  --sign
+```
+
+Responsibilities:
+- Read last line of chain; extract `seq` and `self_hash`.
+- Construct new entry with `seq+1` and `prev_hash = last.self_hash`.
+- Compute `self_hash` over canonical JSON of `{seq, timestamp, event_type, event_data, prev_hash}`.
+- If `--sign`: call `cosign sign-blob --yes --output-signature - --output-certificate -` with the self_hash as input, capture signature + cert.
+- Append the full entry as one ndjson line.
+- Commit (the workflow handles the push).
+
+### 2. `scripts/chain/verify.py`
+
+Called by `audit-verify.yml` nightly. Signature:
+
+```bash
+python scripts/chain/verify.py audit-log/chain.ndjson
+```
+
+Returns exit code 0 on fully-valid chain, non-zero with a line-pointer on failure.
+
+Responsibilities:
+- Parse each line as JSON (ndjson).
+- Validate `seq` is monotonically increasing, no gaps.
+- Validate `prev_hash` of line N equals `self_hash` of line N-1.
+- Recompute `self_hash` from canonical JSON; must match stored value.
+- Verify `signature` against `self_hash` using `cosign verify-blob` with `--certificate-identity-regexp` matching the expected workflow subject.
+- Print progress every 100 entries for large chains.
+
+### 3. `.github/workflows/audit-log.yml` changes
+
+Add a new step after the existing ledger.json write:
+
+```yaml
+- name: Append to Merkle chain
+  run: |
+    jq -n --arg sha "$GITHUB_SHA" --arg ref "$GITHUB_REF" \
+          --arg run "$GITHUB_RUN_ID" --arg actor "$GITHUB_ACTOR" \
+          --arg repo "$GITHUB_REPOSITORY" --arg wf "$GITHUB_WORKFLOW" \
+      '{repo:$repo, sha:$sha, ref:$ref, workflow:$wf, run_id:$run, actor:$actor}' \
+      > /tmp/event.json
+    python scripts/chain/append.py \
+      --event-type build.completed \
+      --event-data /tmp/event.json \
+      --chain audit-log/chain.ndjson \
+      --sign
+  env:
+    COSIGN_EXPERIMENTAL: "1"     # keyless flow
+```
+
+Require `permissions: id-token: write` on the job for Sigstore OIDC.
+
+### 4. `.github/workflows/audit-verify.yml` (new)
+
+Nightly at 03:00 UTC + on-demand dispatch:
+
+```yaml
+name: Audit Chain Verify
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@<PINNED_SHA>
+        with: { persist-credentials: false }
+      - uses: actions/setup-python@<PINNED_SHA>
+        with: { python-version: "3.12" }
+      - name: Install cosign
+        run: |
+          curl -sSfLO https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-amd64
+          chmod +x cosign-linux-amd64
+          sudo mv cosign-linux-amd64 /usr/local/bin/cosign
+      - name: Verify chain
+        run: python scripts/chain/verify.py audit-log/chain.ndjson
+      - name: Open issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "🚨 Audit chain verification FAILED — $(date -u +%F)" \
+            --label "incident,audit,critical" \
+            --body "The nightly audit chain verify failed. See the run logs. Do not merge any PRs until resolved."
+```
+
+### 5. Docs
+
+`docs/compliance/audit-chain.md`:
+- Format spec (the block above).
+- Verification command for a user:
+  ```bash
+  python scripts/chain/verify.py audit-log/chain.ndjson
+  ```
+- What to do if verify fails:
+  - Do NOT attempt to "fix" the chain by rewriting.
+  - Open an incident issue.
+  - Snapshot the current chain to `audit-log/broken/<date>/`.
+  - Investigate the history. A break means either a bug in the append path,
+    a force-push slipped through, or a malicious commit landed.
+  - Resolution involves a human-authored genesis entry continuing a new chain
+    with a `chain.reseed` event pointing to the last-known-good seq.
+- Retention policy: chain.ndjson in repo (hot, 12 months), weekly snapshots
+  to S3 Object Lock (warm, 7 years), deep archive (cold, indefinite).
+
+## Testing strategy
+
+Unit tests under `tests/chain/test_append.py` and `tests/chain/test_verify.py`:
+
+```python
+def test_append_genesis(tmp_path):
+    chain = tmp_path / "chain.ndjson"
+    append(chain_path=chain, event_type="chain.genesis", event_data={...}, sign=False)
+    lines = chain.read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["seq"] == 1
+    assert entry["prev_hash"] == "sha256:" + "0"*64
+
+def test_append_chains_correctly(tmp_path):
+    # append genesis
+    # append second
+    # assert entry2["prev_hash"] == entry1["self_hash"]
+    ...
+
+def test_verify_detects_tampered_payload(tmp_path):
+    # build valid 3-entry chain
+    # modify entry 2's event_data
+    # assert verify() returns non-zero with pointer to line 2
+    ...
+
+def test_verify_detects_gap(tmp_path):
+    # build chain with seq 1, 2, 4 (missing 3)
+    # assert verify fails at line 3
+    ...
+
+def test_verify_detects_prev_hash_mismatch(tmp_path):
+    # build valid chain
+    # change entry 2's prev_hash to arbitrary value
+    # assert verify fails at line 2
+    ...
+```
+
+Run without `--sign` in CI for speed; a separate `@signed` marked integration
+test runs the full cosign path once.
+
+## Verification
+
+After merge:
+
+1. The next run of `audit-log.yml` (via a trivial commit) must append a
+   genuine entry to `chain.ndjson` with a real Sigstore signature.
+2. Running `python scripts/chain/verify.py audit-log/chain.ndjson` must
+   return exit 0.
+3. A deliberate tamper test:
+   ```bash
+   sed -i 's/build.completed/build.tampered/' audit-log/chain.ndjson
+   python scripts/chain/verify.py audit-log/chain.ndjson; echo $?
+   # expect non-zero exit + clear error message pointing to tampered line
+   git checkout audit-log/chain.ndjson
+   ```
+4. The nightly verify job runs green.
+
+## Notes for the agent
+
+- Canonical JSON: use `json.dumps(..., sort_keys=True, separators=(',', ':'))`
+  as the canonical form for hashing. Watch for float precision; if you need
+  floats in event_data, serialize them as strings.
+- `cosign sign-blob` with `--yes` is non-interactive and uses the ambient
+  OIDC token. Test locally with `COSIGN_IDENTITY_TOKEN=$(gh auth token)` ONLY
+  for local smoke; production uses GitHub's OIDC.
+- `rekor_log_index` is returned by cosign in a separate output stream; parse
+  from stderr or use the json output format of cosign 2.4+.
+- Be defensive about unicode: hash before encoding, encode as UTF-8 without
+  BOM, never use `str.encode("utf-8-sig")`.
+
+## References
+
+- Sigstore / cosign docs: keyless signing, Rekor
+- RFC 8785 (JSON Canonicalization Scheme) — reference but we use a simpler form
+- HIPAA §164.312(b) — audit controls
+- 21 CFR Part 11 §11.10(e) — secure, computer-generated, time-stamped audit trails
+- Linux Foundation: "Sigstore Keyless: Cosigning Without Keys"

--- a/copilot-tasks/phase-06-iec62304/task-01-iec62304-traceability-workflow.md
+++ b/copilot-tasks/phase-06-iec62304/task-01-iec62304-traceability-workflow.md
@@ -1,0 +1,299 @@
+---
+title: "Build IEC 62304 traceability workflow and DHF scaffold"
+phase: phase-06
+slug: iec62304-traceability-workflow
+preferred-agent: copilot
+preflight-confirmation: true
+estimated-complexity: l
+
+depends-on:
+  - custom-properties
+
+goal: >
+  Produce a reusable workflow that, for any repo with `iec62304-class` set to
+  class-a/b/c, reads requirement/hazard/test-map YAML files, verifies every
+  requirement is implemented and tested, every hazard has a risk control,
+  every risk control has code and test, and fails the PR if any gap exists.
+  Also build the initial DHF scaffold that the workflow reads.
+
+acceptance-criteria:
+  - "`.github/workflows/reusable-iec62304-traceability.yml` generated, callable from any clinical repo"
+  - "`scripts/traceability/build_matrix.py` parses dhf/**/*.yaml and emits traceability-matrix.json and traceability-matrix.html"
+  - "`scripts/traceability/check_gaps.py` returns exit 0 only if every SW-### has >=1 test and every HZ-### has >=1 RC-###"
+  - "A template DHF skeleton under `templates/dhf/` that can be copied into any new clinical repo"
+  - "Schemas validated: `policies/dhf/schemas/requirements.schema.json`, `hazard-analysis.schema.json`, `unit-test-map.schema.json`"
+  - "`docs/compliance/dhf-guide.md` explains the whole flow"
+  - "A sample repo (e.g., a fork or scratch repo labeled `class-b`) demonstrates the workflow passing and failing with deliberate gaps"
+
+files-to-touch:
+  - ".github/workflows/reusable-iec62304-traceability.yml"
+  - "scripts/traceability/build_matrix.py"
+  - "scripts/traceability/check_gaps.py"
+  - "scripts/traceability/templates/matrix.html.j2"
+  - "policies/dhf/schemas/requirements.schema.json"
+  - "policies/dhf/schemas/hazard-analysis.schema.json"
+  - "policies/dhf/schemas/unit-test-map.schema.json"
+  - "templates/dhf/requirements/software-requirements.yaml"
+  - "templates/dhf/risk/hazard-analysis.yaml"
+  - "templates/dhf/verification/unit-test-map.yaml"
+  - "templates/dhf/classification.md"
+  - "templates/dhf/README.md"
+  - "docs/compliance/dhf-guide.md"
+
+files-not-to-touch:
+  - "AGENTS.md"
+  - "audit-log/**"
+  - ".github/workflows/audit-log.yml"
+  - "policies/rulesets/**"
+
+tests-required: |
+  - Unit tests under `tests/traceability/`:
+    - parses a valid requirements.yaml
+    - rejects duplicate SW-### IDs
+    - rejects hazard with severity but no probability
+    - check_gaps succeeds on a fully-mapped fixture
+    - check_gaps fails with correct line references on:
+      * requirement with no test
+      * hazard with no risk control
+      * risk control not cited in any requirement
+      * test citing a retired requirement
+  - Integration test: build_matrix.py on a fixture emits HTML that opens
+    in a browser (smoke-render only, no assertion on visuals) and JSON
+    that parses as a valid traceability matrix.
+  - `actionlint .github/workflows/reusable-iec62304-traceability.yml`.
+
+standards:
+  - "IEC 62304 §5.2 (Software requirements analysis)"
+  - "IEC 62304 §5.3 (Software architectural design)"
+  - "IEC 62304 §5.5 (Software unit implementation and verification)"
+  - "IEC 62304 §5.6 (Software integration and integration testing)"
+  - "IEC 62304 §5.7 (Software system testing)"
+  - "ISO 14971 §7.1 (Risk control option analysis)"
+  - "ISO 14971 §7.4 (Risk control measure implementation)"
+  - "FDA Guidance: Content of Premarket Submissions for Device Software Functions (2023)"
+
+rollback: >
+  Mark the reusable workflow as skippable via input flag; existing repos
+  that call it continue to call, but new repos can bypass. DHF template
+  remains as reference material.
+
+labels:
+  - "compliance"
+  - "iec62304"
+  - "iso14971"
+  - "clinical"
+
+requires-human-after: review
+
+---
+
+## Context
+
+IEC 62304 §5 requires a documented lifecycle where every software requirement
+can be traced to implementing code and verifying tests, and every hazard
+identified under ISO 14971 has risk-control measures. In practice this is
+done with a spreadsheet or — in a code-as-docs world — with YAML files the
+CI pipeline reads.
+
+This task builds that pipeline. After it lands, any clinical repo that wants
+to credibly support a 510(k) submission, a notified body review, or an
+internal audit has the evidence structure in place.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  dhf/                          (the evidence)               │
+│  ├── requirements/software-requirements.yaml                │
+│  ├── risk/hazard-analysis.yaml                              │
+│  ├── verification/unit-test-map.yaml                        │
+│  └── classification.md                                      │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│  src/**/*                      (annotations in code)        │
+│  /// @requirement SW-042                                    │
+│  /// @risk-control RC-007                                   │
+│  fn validate_ga(ga: GestationalAge) -> Result<...>          │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│  tests/**/*                    (test-to-req mapping)        │
+│  @requirement("SW-042")                                     │
+│  def test_rejects_below_22w(): ...                          │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│  reusable-iec62304-traceability.yml                         │
+│  1. build_matrix.py   → JSON + HTML                         │
+│  2. check_gaps.py     → exit 0 or fail with gap list        │
+│  3. uploads matrix as workflow artifact                     │
+│  4. on-PR: comments summary on the PR                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Approach
+
+### 1. Schemas (`policies/dhf/schemas/*.json`)
+
+JSON Schema for each DHF YAML. Used by `build_matrix.py` to validate inputs
+and by the editor (via YAML Language Server `# yaml-language-server: $schema=...`
+hint at the top of each file) to give IDE autocomplete.
+
+Key fields per `dhf.instructions.md`. Require:
+- `id` pattern `SW-\d{3,}` for software requirements
+- `id` pattern `HZ-\d{3,}` for hazards
+- `id` pattern `RC-\d{3,}` for risk controls
+- severity ∈ {negligible, minor, serious, critical, catastrophic}
+- probability ∈ {frequent, probable, occasional, remote, improbable, incredible}
+
+### 2. `build_matrix.py`
+
+Input: `dhf/` directory.
+Output:
+- `dhf/releases/<version>/traceability-matrix.json` — machine-readable.
+- `dhf/releases/<version>/traceability-matrix.html` — human-readable, single file with embedded CSS, sortable table (plain `<table>` + small JS).
+
+Each row of the matrix:
+```
+SW-###  | title | parent SYS-### | implemented? | implemented-in | tests (list) | test-pass-rate | risk-controls | status
+```
+
+Plus a second table for hazards:
+```
+HZ-### | title | severity | probability | risk-level | controls (list) | controls-covered? | residual-risk
+```
+
+### 3. `check_gaps.py`
+
+Rules (each failure prints a specific line number in the YAML + file):
+
+- Every non-retired `SW-###` with status != `draft` must have at least one entry in `unit-test-map.yaml` listing it under `verifies:`.
+- Every `SW-###` with `implemented: location: <path>` must have that path exist in the repo and the specified symbol must be annotated with the matching `@requirement` (language-dispatch: parse comments for Rust/Python/Julia/TypeScript/Go).
+- Every `HZ-###` with residual severity ≥ serious must have at least one `RC-###` in `controls:` with that RC implemented (searched in code annotations).
+- Every `RC-###` cited from a hazard must be cited from at least one `SW-###` in the requirements file.
+- No duplicate IDs anywhere.
+- No test citing a retired requirement (warn, don't fail — encourage cleanup).
+
+Exit codes:
+- 0: all checks pass
+- 1: hard gap (missing test, missing RC, invalid ID)
+- 2: schema/parse error (bad YAML, wrong types)
+
+### 4. `reusable-iec62304-traceability.yml`
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      dhf-path:
+        type: string
+        default: "dhf"
+      fail-on-gap:
+        type: boolean
+        default: true
+      version:
+        type: string
+        default: "HEAD"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  traceability:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@<PINNED_SHA>
+        with: { persist-credentials: false }
+      - uses: actions/setup-python@<PINNED_SHA>
+        with: { python-version: "3.12" }
+      - run: pip install pyyaml jsonschema jinja2
+      - name: Build traceability matrix
+        run: |
+          python scripts/traceability/build_matrix.py \
+            --dhf ${{ inputs.dhf-path }} \
+            --version ${{ inputs.version }} \
+            --out dhf/releases/${{ inputs.version }}/
+      - name: Check gaps
+        id: gaps
+        run: |
+          python scripts/traceability/check_gaps.py --dhf ${{ inputs.dhf-path }}
+        continue-on-error: ${{ !inputs.fail-on-gap }}
+      - name: Upload matrix
+        uses: actions/upload-artifact@<PINNED_SHA>
+        with:
+          name: traceability-matrix
+          path: dhf/releases/${{ inputs.version }}/
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # compose a markdown summary from traceability-matrix.json and post as comment
+          python scripts/traceability/pr_comment.py --pr ${{ github.event.pull_request.number }}
+```
+
+### 5. DHF template
+
+Under `templates/dhf/` — what `scripts/bootstrap-dhf.sh <target-repo>` copies
+into a new clinical repo. Every file is minimally populated with:
+- An example SW-001 requirement with fake-but-realistic content.
+- An example HZ-001 hazard with its RC-001.
+- An example test-map binding SW-001 to a nonexistent test (so `check_gaps`
+  fails on the template, forcing the user to replace stubs before the first
+  release).
+- A README explaining the layout.
+
+### 6. `docs/compliance/dhf-guide.md`
+
+Full user-facing guide:
+- How to classify a repo (ref phase-06 task on classification wizard, when
+  that lands).
+- How to populate the YAML files, with an annotated example.
+- Conventions for annotating code.
+- How the workflow fits into CI.
+- How to cut a release with DHF bound (forward ref to phase-06 release task).
+- Common pitfalls: retired vs. deleted requirements, ID reuse, coverage
+  vs. traceability (they're different).
+
+## Test strategy
+
+Fixtures under `tests/traceability/fixtures/`:
+- `valid-minimal/` — 2 reqs, 1 hazard, 1 RC, all tested. Passes.
+- `missing-test/` — SW-002 has no test entry. check_gaps fails at SW-002.
+- `orphan-rc/` — RC-003 cited by a hazard but no requirement cites it. check_gaps fails.
+- `duplicate-id/` — two SW-001 entries. check_gaps fails with line refs.
+- `retired-req-tested/` — test cites a retired req. check_gaps warns (exit 0 with warning).
+
+Run with `pytest tests/traceability/`.
+
+## Notes for the agent
+
+- This task touches many files; the diff will likely exceed 400 lines.
+  That's acceptable here because the task is inherently cohesive — schemas,
+  parser, tests, workflow, docs form one unit. However, if the diff grows
+  past 1000 lines, SPLIT: into (schemas + template) as task-01 and (workflow
+  + check_gaps + docs) as task-02.
+- Annotation parsing is language-specific. Start with Python and Rust
+  (regex over `//` and `#` comments). Julia and TypeScript can be follow-up
+  tasks. Document clearly which languages are supported in the first release.
+- The HTML matrix does not need to be pretty. A plain sortable table with
+  good colors for pass/fail status is enough. Use a tiny vendored JS library
+  like `tablesorter` or write 20 lines of vanilla JS — do not pull in
+  jQuery or React.
+
+## References
+
+- IEC 62304:2006+A1:2015
+- ISO 14971:2019
+- FDA: "Content of Premarket Submissions for Device Software Functions"
+  (June 2023, final guidance)
+- FDA: "Cybersecurity in Medical Devices: Quality System Considerations"
+  (Sept 2023)
+- AAMI TIR45 — Guidance on the use of Agile practices in the development of medical device software
+- NTIA: Framing Software Component Transparency (SBOM minimum elements)

--- a/copilot-tasks/phase-08-ha-patterns/task-01-sci-resilience-crate.md
+++ b/copilot-tasks/phase-08-ha-patterns/task-01-sci-resilience-crate.md
@@ -1,0 +1,190 @@
+---
+title: "Scaffold sci-resilience crate (timeout/retry/circuit-breaker)"
+phase: phase-08
+slug: sci-resilience-crate
+preferred-agent: copilot
+preflight-confirmation: false
+estimated-complexity: m
+
+goal: >
+  Add a `sci-resilience` crate to the `rust-sci-core` workspace implementing
+  the four patterns every clinical service must use: timeout, retry with
+  jittered exponential backoff, circuit breaker, and bulkhead. Make it the
+  required HTTP-client wrapper for any service that calls external
+  dependencies.
+
+acceptance-criteria:
+  - "New crate `sci-resilience` added to the workspace with dependency only on sci-units, thiserror, tokio, tracing"
+  - "Public API: `RetryPolicy`, `CircuitBreaker`, `Bulkhead`, `timeout()` wrapper, `resilient_call()` combinator"
+  - "Property-based tests via proptest: retry never exceeds policy max-attempts, circuit-breaker state transitions are monotonic, bulkhead never over-admits"
+  - "Doc examples compile and run (doctests green)"
+  - "README with integration example showing a resilient reqwest client"
+  - "No `unsafe`, no `panic!` in non-test code"
+
+files-to-touch:
+  - "crates/sci-resilience/Cargo.toml"
+  - "crates/sci-resilience/src/lib.rs"
+  - "crates/sci-resilience/src/timeout.rs"
+  - "crates/sci-resilience/src/retry.rs"
+  - "crates/sci-resilience/src/circuit_breaker.rs"
+  - "crates/sci-resilience/src/bulkhead.rs"
+  - "crates/sci-resilience/tests/property_tests.rs"
+  - "crates/sci-resilience/README.md"
+  - "Cargo.toml"                                   # workspace members
+
+files-not-to-touch:
+  - "AGENTS.md"
+  - "audit-log/**"
+  - "other crates' sources (this task is isolated to sci-resilience)"
+
+tests-required: |
+  - `cargo test -p sci-resilience` green
+  - `cargo clippy -p sci-resilience -- -D warnings` clean
+  - `cargo doc -p sci-resilience --no-deps` builds without warnings
+  - `cargo nextest run -p sci-resilience` green
+  - proptest with 1000 cases per property
+
+standards:
+  - "NIST SSDF PW.5 — produce well-secured software (defensive coding)"
+  - "ISO/IEC 25010 — reliability characteristic"
+  - "IEC 62304 §5.5.1 — implementation rules (applied to the services that will use this)"
+
+rollback: >
+  Remove the crate from `Cargo.toml` workspace members. Services that have
+  adopted it must revert to their prior HTTP-client code in a separate PR.
+
+labels:
+  - "rust"
+  - "resilience"
+  - "infrastructure"
+
+---
+
+## Context
+
+Every service in the org that talks to an external dependency (another
+service, Postgres, Redis, a FHIR server) needs these four patterns, and
+every service currently gets them wrong in subtly different ways. Making
+them a shared crate:
+
+1. Guarantees consistent behavior (a request that times out in service A
+   times out the same way in service B).
+2. Centralizes observability (every resilience event emits the same metrics
+   and spans).
+3. Makes security review fast (one crate to audit vs. N).
+4. Provides a drop-in upgrade path when we tune defaults.
+
+The crate wraps `reqwest`, `sqlx`, and any `tokio`-based async call — it's
+call-site-agnostic.
+
+## Public API sketch
+
+```rust
+// retry
+pub struct RetryPolicy {
+    pub max_attempts: u32,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+    pub jitter: JitterStrategy,   // None | Full | Equal | Decorrelated
+}
+impl RetryPolicy {
+    pub fn exponential() -> Self { ... }
+    pub fn for_database() -> Self { ... }    // conservative defaults
+    pub fn for_idempotent_http() -> Self { ... }
+}
+
+// circuit breaker
+pub struct CircuitBreaker {
+    pub failure_threshold: u32,
+    pub success_threshold: u32,
+    pub half_open_after: Duration,
+}
+// states: Closed → Open → HalfOpen → Closed|Open
+
+// bulkhead
+pub struct Bulkhead {
+    pub max_concurrent: usize,
+    pub queue_depth: usize,
+}
+
+// combinator
+pub async fn resilient_call<F, T, E>(
+    policy: ResiliencePolicy,
+    op: F,
+) -> Result<T, ResilienceError<E>>
+where
+    F: Fn() -> BoxFuture<'static, Result<T, E>>,
+    E: std::error::Error + Send + 'static,
+{ ... }
+
+pub struct ResiliencePolicy {
+    pub timeout: Option<Duration>,
+    pub retry: Option<RetryPolicy>,
+    pub breaker: Option<Arc<CircuitBreaker>>,
+    pub bulkhead: Option<Arc<Bulkhead>>,
+}
+```
+
+## Properties to test
+
+With `proptest`:
+
+1. **Retry count invariant**: For any policy P and any `op` that always fails,
+   the number of invocations is exactly `min(P.max_attempts, retries_allowed)`.
+2. **Backoff monotonicity (without jitter)**: `backoff(n+1) >= backoff(n)` up
+   to `max_backoff` cap.
+3. **Jitter bound**: with `Full` jitter, actual sleep ∈ `[0, base]`; with
+   `Equal` jitter, actual sleep ∈ `[base/2, base/2 + rand(base/2)]`.
+4. **Circuit breaker monotone transitions**: starting Closed, a sequence of
+   failures ≥ failure_threshold → Open. From Open, after `half_open_after`,
+   next call → HalfOpen. From HalfOpen, success_threshold consecutive
+   successes → Closed; any failure → Open.
+5. **Bulkhead over-admission impossibility**: at no point does the number of
+   in-flight operations exceed `max_concurrent`.
+
+## Observability
+
+Every layer emits:
+- `tracing::Span` at `info` level with operation name.
+- Metrics (via `metrics` crate facade): `resilience_calls_total{op,state}`,
+  `resilience_failures_total{op,reason}`, `resilience_circuit_state{op}`,
+  `resilience_bulkhead_depth{op}`.
+
+## Usage example (goes in README)
+
+```rust
+use sci_resilience::{ResiliencePolicy, RetryPolicy, CircuitBreaker, resilient_call};
+use std::{sync::Arc, time::Duration};
+
+let breaker = Arc::new(CircuitBreaker::default());
+let policy = ResiliencePolicy {
+    timeout: Some(Duration::from_secs(5)),
+    retry: Some(RetryPolicy::for_idempotent_http()),
+    breaker: Some(Arc::clone(&breaker)),
+    bulkhead: None,
+};
+
+let client = reqwest::Client::new();
+let response = resilient_call(policy, || {
+    let client = client.clone();
+    Box::pin(async move {
+        client.get("https://fhir.example.org/Patient/123")
+              .send().await?.error_for_status()
+    })
+}).await?;
+```
+
+## Verification
+
+- `cargo test -p sci-resilience` — all unit + proptest tests green.
+- `cargo clippy -p sci-resilience -- -D warnings` — clean.
+- `cargo doc -p sci-resilience --no-deps --open` — docs render.
+- Benchmark the overhead of wrapping a no-op call: adds < 10 μs on tokio
+  multi-thread runtime. Include the numbers in the PR body.
+
+## References
+
+- Release It! (Michael Nygard) — Chapters on timeouts, circuit breakers,
+  bulkheads.
+- Marc Brooker: "Exponential Backoff and Jitter" (AWS Architecture Blog).
+- AWS: "Timeouts, retries, and backoff with jitter" in the Builders' Library.

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -1,0 +1,257 @@
+# How the Agentic Workflow Works (End to End)
+
+This document describes — in human terms — how an idea moves from "we should
+harden secret scanning" to "merged PR that did it" without the roadmap owner
+touching the keyboard for most of the journey.
+
+## The four primitives
+
+1. **Task file** — a markdown file under `copilot-tasks/phase-NN-*/task-*.md`
+   with YAML frontmatter that fully specifies one reviewable unit of work.
+2. **GitHub issue** — auto-generated from the task file, assigned to an
+   agent.
+3. **Agent PR** — what the agent produces. Branch named
+   `agent/<phase>/<slug>-<issue#>`.
+4. **Guardrails workflow** — automatically runs on every agent PR and
+   enforces the rules in `AGENTS.md`.
+
+Everything else (CI, PHI scan, SBOM, audit logging) already exists; the
+agent's PR flows through the same pipeline as any human PR, plus the extra
+agent-specific guardrails.
+
+## The five-layer instruction stack
+
+Agents (Copilot, Claude Code, Codex, Cursor) read instructions from five
+layers, stricter wins on safety-critical rules, narrower wins on style:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ 1. AGENTS.md §1 (hard refusals)                                     │
+│    Non-overridable. PHI, compliance bypass, force-push, etc.        │
+├─────────────────────────────────────────────────────────────────────┤
+│ 2. The triggering issue's body                                      │
+│    Task-specific rules. "Only modify X.", "Use Y approach."         │
+├─────────────────────────────────────────────────────────────────────┤
+│ 3. Path-scoped .github/instructions/*.md                            │
+│    Auto-applied based on file path via `applyTo:` frontmatter.      │
+├─────────────────────────────────────────────────────────────────────┤
+│ 4. AGENTS.md §2..§13 + .github/copilot-instructions.md              │
+│    Repo-wide conventions.                                           │
+├─────────────────────────────────────────────────────────────────────┤
+│ 5. Per-agent defaults (Copilot, Claude Code, etc.)                  │
+│    Baseline behavior.                                               │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Walkthrough: "pin all actions to SHAs"
+
+### Step 1 — Task file exists
+
+Already written: `copilot-tasks/phase-01-platform-hardening/task-02-pin-actions-sha.md`.
+The frontmatter declares:
+
+- `slug: pin-actions-sha`
+- `files-to-touch: [.github/workflows/**/*.yml, .github/dependabot.yml]`
+- `acceptance-criteria: [...]`
+- `preflight-confirmation: false`
+
+### Step 2 — Seed the issue
+
+A human (or the weekly cron) triggers `seed-roadmap-issues.yml`:
+
+```
+Actions → "Seed Roadmap Issues" → Run workflow
+  phase: phase-01
+  dry-run: false
+  assign-to: copilot
+```
+
+`scripts/seed_issues.py` walks `copilot-tasks/phase-01-*/`, sees the task,
+checks for an existing issue with the canonical title, finds none, creates
+a new issue titled `[agent-task] phase-01/pin-actions-sha: Pin all workflow
+actions to 40-char SHAs` with labels `agent-task`, `phase:01`,
+`task:pin-actions-sha`, `security`, `supply-chain`, `quick-win` and assigns
+it to `@copilot`.
+
+### Step 3 — Copilot picks it up
+
+GitHub Copilot coding agent is notified via its issue-assignment webhook.
+It spins up an ephemeral environment. The `copilot-setup-steps.yml` workflow
+runs first to pre-install Node, Python, Go, Rust, Julia, actionlint,
+yamllint, cosign, syft, grype, FHIR validator. The agent now has a ready
+environment.
+
+### Step 4 — The agent reads context
+
+Before editing a single file:
+
+1. Reads `AGENTS.md` (universal rules).
+2. Reads `.github/copilot-instructions.md` (Copilot operating modes).
+3. Reads `.github/instructions/workflows.instructions.md` because its
+   `applyTo: .github/workflows/**/*.yml` pattern matches the files it plans
+   to touch.
+4. Reads the linked task file (`task-02-pin-actions-sha.md`) end to end.
+5. Reads the current state of the workflows it's about to change.
+
+### Step 5 — The agent acts
+
+It runs (inside its sandboxed environment):
+
+```bash
+npm install --global pin-github-action@1.x
+find .github/workflows -name '*.yml' -print0 | \
+  xargs -0 -n1 pin-github-action --allow-empty-actions-list
+```
+
+Adds `.github/dependabot.yml` per the task body. Runs `actionlint` — clean.
+Runs the verification grep — empty. Runs `yamllint --strict` — clean.
+
+### Step 6 — The agent opens a PR
+
+Branch: `agent/phase-01/pin-actions-sha-<issue#>`.
+
+Commits (Conventional Commits + `Refs:` footer):
+
+```
+security: pin all workflow actions to SHAs
+
+Replaces tag-based `uses:` with commit-SHA pins; adds Dependabot
+config for github-actions ecosystem. Eliminates the last Scorecard
+Pinned-Dependencies gap.
+
+Refs: #<issue>
+```
+
+PR description fills every section of the template:
+
+- **Summary**: 2 sentences.
+- **Files Changed**: every touched workflow + dependabot.yml.
+- **Acceptance Criteria**: every box checked, with output of the grep and
+  actionlint pasted in.
+- **Tests**: `actionlint` run + `yamllint` run.
+- **Audit Events**: none.
+- **Security Implications**: "Reduces supply-chain attack surface. No new
+  surface added. Failure mode is Dependabot no longer auto-upgrading, which
+  is acceptable (we review Dependabot PRs)."
+- **Standards Touched**: NIST SSDF PW.4, Scorecard Pinned-Dependencies, SLSA
+  v1.0 build.
+- **Rollback**: Revert the merge commit.
+- **Agent Self-Check**: every box checked.
+
+Labels: `agent:copilot`, `phase:01`, `task:pin-actions-sha`, `class:<repo-class>`,
+`review:human-required` (or `cooling-off-ok` per task).
+
+### Step 7 — Guardrails run
+
+`copilot-task-guardrails.yml` fires on PR open:
+
+- **detect-agent** — sees `agent/` branch prefix, marks `is-agent=true`,
+  fetches the repo's custom properties, sees `iec62304-class=not-applicable`
+  (this is the `.github` repo, not clinical), `data-classification=internal`.
+- **forbidden-paths** — diffs the PR. No files under `audit-log/`, `dhf/risk/`,
+  `policies/rulesets/`, etc. Passes.
+- **required-compliance-checks-preserved** — grep for added
+  `continue-on-error: true` or `if: false` in the modified required-check
+  workflows. None found. Passes.
+- **pr-description-complete** — every required section present. Passes.
+- **phi-scan-on-diff** — runs the reusable PHI scanner over the diff. Clean
+  (workflow YAML has no PHI patterns).
+- **class-bc-needs-human** — skipped because repo is not Class B/C and not
+  phi-active.
+- **audit-log-agent-pr** — emits a summary JSON to the run's step summary.
+
+All green.
+
+### Step 8 — Regular CI runs
+
+The normal `ci-*.yml` workflows also run. CodeQL, Scorecard, etc. All green.
+
+### Step 9 — Human review
+
+The PR is now assigned for human review per CODEOWNERS. The reviewer sees:
+
+- A clean, single-purpose PR.
+- Every file's change is a one-line pinning.
+- The PR body has the verification evidence baked in.
+- All checks green.
+
+Reviewer approves, merges.
+
+### Step 10 — Audit trail
+
+The `audit-log.yml` workflow runs on merge-to-main, appending a new entry
+to the Merkle chain in `audit-log/chain.ndjson` (after phase-04/task-01
+lands) with Sigstore-signed hash of this PR's commit. The issue auto-closes
+via the `Refs: #<issue>` footer.
+
+### Step 11 — Done
+
+The roadmap owner opens the issue tracker a week later and sees:
+
+- `agent-task` label: 6 closed PRs, 2 in review, 4 queued.
+- Weekly audit report: every agent PR's guardrail evaluation.
+- Scorecard score for `.github`: +12 points on Pinned-Dependencies.
+
+Total roadmap-owner keyboard time for this task: 30 seconds (clicking
+"Run workflow" on the seeder).
+
+## Why this works
+
+- **Task files are the contract.** They are tighter than free-form issues
+  and far tighter than "give Copilot the roadmap and see what it does."
+- **Guardrails are enforced, not advisory.** The `copilot-task-guardrails.yml`
+  is a required status check; a PR cannot merge if it violates
+  AGENTS.md §4.3 even if every human reviewer approves.
+- **The agent can refuse.** `AGENTS.md §1` gives explicit refusal paths; the
+  agent can comment `BLOCKED:` or `RISK:` on an issue without failing.
+- **Every action leaves evidence.** The guardrails workflow emits an audit
+  event for every agent PR, whether it merges or not. This is your
+  regulatory-grade paper trail.
+- **Scope is bounded.** `files-to-touch` is an allow-list; anything outside
+  it that gets modified is flagged. Small, reviewable PRs are the default,
+  not the exception.
+
+## What to do when things break
+
+### The agent misbehaves
+
+- **Takes too broad a scope**: task file's `files-to-touch` was too loose.
+  Tighten it, close the PR, reopen the task.
+- **Asks too many clarifying questions**: the task file lacks context.
+  Add a longer `## Context` section.
+- **Gives up (`BLOCKED:`)**: check the comment; usually a real blocker
+  (missing dependency, property not yet set, permission). Address and
+  re-assign.
+- **Produces a PR that doesn't pass guardrails**: the guardrails are doing
+  their job. The feedback loop is: read the guardrail failure → update the
+  task file so the next task doesn't trip the same rule → re-assign.
+
+### You want to add a new kind of task
+
+1. Write the task file under a new phase directory (or existing).
+2. Commit it.
+3. Run `seed-roadmap-issues.yml`.
+4. Assign to `@copilot` (or let the seeder do it).
+
+### You want to add a new guardrail
+
+1. Extend `copilot-task-guardrails.yml` with a new job.
+2. Document the new rule in `AGENTS.md`.
+3. Announce in `ruralpeds/.github` README so contributors (human and
+   agent) know.
+
+## The 30-day ramp-up
+
+- **Week 1**: seed only phase-01 tasks. Assign one at a time. Watch the PRs
+  closely. Tighten AGENTS.md and task files based on what you see.
+- **Week 2**: seed phase-01 remainder + phase-02. Assign in batches of 3.
+  Review guardrail logs, not just PRs.
+- **Week 3**: seed phase-03 + phase-04. Start letting small Class A PRs
+  use `cooling-off-ok` (self-review after 24h) instead of mandatory human
+  review. Track the cooling-off-ok miss rate.
+- **Week 4**: full steam. Every phase has active agent work. Weekly review
+  of the agent metrics dashboard (how many PRs, merge rate, guardrail-fail
+  rate, lines-per-PR average).
+
+Within 90 days the roadmap owner is mostly writing task files and reviewing,
+not implementing.

--- a/docs/BUNDLE_README.md
+++ b/docs/BUNDLE_README.md
@@ -1,0 +1,99 @@
+# Agentic Copilot Bundle for `ruralpeds/.github`
+
+Drop-in infrastructure that turns your 12-phase enterprise roadmap into an
+agentic pipeline: write a task file → the seeder creates a GitHub issue →
+`@copilot` (or Claude Code, Codex, Cursor) picks it up → the agent opens a
+PR on an `agent/` branch → automated guardrails enforce your clinical and
+regulatory rules → a human reviews → merge → the audit ledger records
+everything.
+
+## What's in this bundle
+
+| File | What it does |
+|---|---|
+| `AGENTS.md` | Universal cross-agent contract. Hard refusals in §1 are non-overridable. |
+| `.github/copilot-instructions.md` | Copilot's primary instruction file. Three operating modes: inline, review, coding-agent. |
+| `.github/instructions/workflows.instructions.md` | Auto-applied when the agent touches `.github/workflows/**/*.yml`. |
+| `.github/instructions/dhf.instructions.md` | Auto-applied under `dhf/**`. Hardens against IEC 62304 documentation mistakes. |
+| `.github/instructions/security.instructions.md` | Auto-applied under auth/authz/audit/security/crypto paths. |
+| `.github/instructions/tests.instructions.md` | Auto-applied under `tests/**`. Property-based, PHI-leak, coverage rules. |
+| `.github/ISSUE_TEMPLATE/agent-task.yml` | Structured form for filing agent-ready tasks by hand. |
+| `.github/workflows/copilot-setup-steps.yml` | Pre-installs Node/Python/Go/Rust/Julia/cosign/syft/grype/FHIR validator in the agent's env. |
+| `.github/workflows/copilot-task-guardrails.yml` | Runs on every agent PR. Enforces AGENTS.md §4.3 (forbidden paths), §3 (PR description), Class-B/C human-review requirement, PHI scan, required-check preservation. |
+| `.github/workflows/seed-roadmap-issues.yml` | Weekly cron + on-demand; reads `copilot-tasks/`, files issues idempotently. |
+| `.github/mcp-config.json` | MCP server config — GitHub API, FHIR validator, org docs. |
+| `scripts/seed_issues.py` | Python script the seed workflow invokes. |
+| `copilot-tasks/README.md` + `_schema.md` | Task-file authoring guide. |
+| `copilot-tasks/phase-01-*/task-*.md` | Three concrete phase-01 tasks, ready to go. |
+| `copilot-tasks/phase-02-*/task-01-slsa-provenance-attest-sbom.md` | SLSA Build L3 + FDA §524B. |
+| `copilot-tasks/phase-04-*/task-01-merkle-chain-audit-ledger.md` | Sigstore-signed Merkle-chained audit log. |
+| `copilot-tasks/phase-06-*/task-01-iec62304-traceability-workflow.md` | Full DHF scaffold + traceability CI. |
+| `copilot-tasks/phase-08-*/task-01-sci-resilience-crate.md` | Resilience patterns as a shared Rust crate. |
+| `docs/AGENT_WORKFLOW.md` | End-to-end human walkthrough. |
+| `INSTALL.md` | How to drop this into your `.github` repo. |
+
+## Quick start
+
+```bash
+# 1. Clone your .github repo and cd in
+git clone https://github.com/ruralpeds/.github.git && cd .github
+git checkout -b agentic-pipeline-bootstrap
+
+# 2. Copy this bundle's contents on top
+cp -a <this-bundle>/. .
+
+# 3. Read INSTALL.md end to end before committing.
+$EDITOR INSTALL.md
+
+# 4. Pin the <PINNED_SHA> placeholders in the workflow files.
+# 5. Commit, push, open a PR, review it yourself carefully.
+
+# 6. After merge, kick off the seeder:
+gh workflow run seed-roadmap-issues.yml \
+  -f phase=phase-01 -f dry-run=true -R ruralpeds/.github
+
+# 7. When dry-run looks right, do it live:
+gh workflow run seed-roadmap-issues.yml \
+  -f phase=phase-01 -f dry-run=false -f assign-to=copilot \
+  -R ruralpeds/.github
+```
+
+## Design principles
+
+1. **Task files are the contract.** Every unit of agent work is a
+   markdown file with YAML frontmatter. The agent, the seeder, and the
+   guardrails all read the same file.
+2. **Guardrails are code, not policy documents.** Rules in `AGENTS.md` that
+   matter (forbidden paths, required sections, class-B/C review) are
+   enforced in `copilot-task-guardrails.yml`. They cannot be bypassed by
+   an agent or a human.
+3. **Scope is narrow.** `files-to-touch` is an allow-list. Single-purpose
+   PRs are the default; drive-by fixes are a separate task.
+4. **Humans stay in the loop where it matters.** Class B/C repos require
+   human review. Clinical-judgment tasks are never filed as agent tasks.
+   The roadmap owner writes the task files; the agent executes them.
+5. **Everything is audited.** Every agent PR emits an audit event. Phase-04
+   upgrades this to a Sigstore-signed Merkle chain with nightly
+   verification.
+
+## Compatibility
+
+The `AGENTS.md` + `.github/copilot-instructions.md` + path-scoped
+`instructions/` pattern works out of the box with:
+
+- **GitHub Copilot** (chat, review, coding agent)
+- **Claude Code** (reads `AGENTS.md` and `CLAUDE.md`; optionally symlink
+  `CLAUDE.md → AGENTS.md`)
+- **OpenAI Codex** (reads `AGENTS.md`; pass `--agents-file AGENTS.md` on CLI)
+- **Cursor** (reads `.cursorrules` — duplicate or symlink to `AGENTS.md`)
+- **Windsurf** (similar; reads `.windsurfrules` or repo instructions)
+
+The task files are agent-neutral. Any agent that can be assigned to a
+GitHub issue can work them.
+
+## Questions?
+
+Read `docs/AGENT_WORKFLOW.md` for the end-to-end narrative.
+
+Contributions to this bundle: PR against `ruralpeds/.github` with the
+`infra` label.

--- a/scripts/seed_issues.py
+++ b/scripts/seed_issues.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""seed_issues.py — Convert copilot-tasks/phase-NN-*/task-*.md into GitHub issues.
+
+Each task file has YAML frontmatter describing the task; this script:
+
+  1. Walks copilot-tasks/ (optionally filtered to one phase).
+  2. For each task file, computes a stable canonical title.
+  3. Checks whether an open or closed-within-90d issue exists for that title.
+  4. If not, files a new issue using the agent-task template fields.
+  5. Optionally assigns the new issue to a user (e.g. 'copilot').
+
+Run via .github/workflows/seed-roadmap-issues.yml, or locally:
+
+    GH_TOKEN=... python scripts/seed_issues.py --phase all --repo ruralpeds/.github
+
+The script only READS when --dry-run is set. Otherwise it calls `gh issue create`
+via subprocess. Never fails the workflow on a single task's failure; it reports
+and continues.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+TASKS_DIR = ROOT / "copilot-tasks"
+
+
+@dataclass
+class Task:
+    phase: str  # e.g. "phase-01-platform-hardening"
+    slug: str  # e.g. "pin-actions-sha"
+    path: Path
+    frontmatter: dict[str, Any]
+    body: str
+
+    @property
+    def phase_num(self) -> str:
+        m = re.match(r"phase-(\d+)", self.phase)
+        return m.group(1) if m else "00"
+
+    @property
+    def title(self) -> str:
+        short = self.frontmatter.get("title", self.slug)
+        return f"[agent-task] {self.phase}/{self.slug}: {short}"
+
+    @property
+    def labels(self) -> list[str]:
+        base = [
+            "agent-task",
+            f"phase:{self.phase_num}",
+            f"task:{self.slug}",
+        ]
+        extra = self.frontmatter.get("labels", []) or []
+        return sorted(set(base + extra))
+
+    @property
+    def preferred_agent(self) -> str:
+        return self.frontmatter.get("preferred-agent", "copilot")
+
+
+def parse_task(path: Path) -> Task | None:
+    text = path.read_text(encoding="utf-8")
+    m = re.match(r"^---\n(.*?)\n---\n(.*)$", text, re.DOTALL)
+    if not m:
+        print(f"[skip] {path} — no frontmatter", file=sys.stderr)
+        return None
+    try:
+        fm = yaml.safe_load(m.group(1))
+    except yaml.YAMLError as e:
+        print(f"[skip] {path} — bad yaml: {e}", file=sys.stderr)
+        return None
+    if not isinstance(fm, dict):
+        print(f"[skip] {path} — frontmatter is not a mapping", file=sys.stderr)
+        return None
+    phase = path.parent.name
+    slug = path.stem.split("-", 1)[1] if path.stem.startswith("task-") else path.stem
+    return Task(phase=phase, slug=slug, path=path, frontmatter=fm, body=m.group(2).strip())
+
+
+def discover(phase_filter: str) -> list[Task]:
+    tasks: list[Task] = []
+    if not TASKS_DIR.exists():
+        print(f"[error] {TASKS_DIR} does not exist", file=sys.stderr)
+        return tasks
+    for phase_dir in sorted(TASKS_DIR.iterdir()):
+        if not phase_dir.is_dir() or not phase_dir.name.startswith("phase-"):
+            continue
+        if phase_filter != "all" and phase_dir.name != phase_filter and not phase_dir.name.startswith(phase_filter):
+            continue
+        for task_file in sorted(phase_dir.glob("task-*.md")):
+            t = parse_task(task_file)
+            if t is not None:
+                tasks.append(t)
+    return tasks
+
+
+def render_body(t: Task, repo: str) -> str:
+    fm = t.frontmatter
+    acceptance = fm.get("acceptance-criteria", [])
+    allowed = fm.get("files-to-touch", [])
+    forbidden = fm.get("files-not-to-touch", [])
+    tests = fm.get("tests-required", "See task file.")
+    standards = fm.get("standards", [])
+    rollback = fm.get("rollback", "Revert the merge commit.")
+    preflight = fm.get("preflight-confirmation", False)
+
+    def bullets(items: Any) -> str:
+        if isinstance(items, list):
+            return "\n".join(f"- {x}" for x in items) or "_(none)_"
+        return str(items)
+
+    def checkboxes(items: Any) -> str:
+        if isinstance(items, list):
+            return "\n".join(f"- [ ] {x}" for x in items) or "_(none)_"
+        return str(items)
+
+    out = dedent(
+        f"""\
+        <!-- seeded-from: {t.path.relative_to(ROOT)} -->
+
+        **Phase:** `{t.phase}` &nbsp;•&nbsp; **Slug:** `{t.slug}` &nbsp;•&nbsp; **Preferred agent:** `{t.preferred_agent}`
+
+        **Linked task file:** [`{t.path.relative_to(ROOT)}`](../blob/main/{t.path.relative_to(ROOT).as_posix()})
+
+        **Preflight confirmation required:** `{str(preflight).lower()}`
+
+        ---
+
+        ## Goal
+
+        {fm.get("goal", "(no goal stated — see task file)")}
+
+        ## Acceptance criteria
+
+        {checkboxes(acceptance)}
+
+        ## Files the agent may modify
+
+        {bullets(allowed)}
+
+        ## Files the agent MUST NOT modify
+
+        {bullets(forbidden)}
+
+        Additionally, all paths listed in `AGENTS.md §4.3` are forbidden.
+
+        ## Tests required
+
+        {tests}
+
+        ## Standards touched
+
+        {bullets(standards)}
+
+        ## Rollback
+
+        {rollback}
+
+        ---
+
+        ### Task body
+
+        {t.body}
+
+        ---
+
+        ### Agent execution contract
+
+        1. Read `AGENTS.md`, `.github/copilot-instructions.md`, and every `.github/instructions/*.md` whose `applyTo` pattern matches any file you'll touch.
+        2. Read the linked task file in full.
+        3. Branch: `agent/{t.phase_num}/{t.slug}-<this-issue-number>`.
+        4. One task per PR. Split follow-ups into new issues.
+        5. Every acceptance criterion must be checked or explicitly explained before opening the PR.
+        6. Fill the PR description template in full (see `.github/copilot-instructions.md`).
+        7. If blocked, comment `ASK:`, `BLOCKED:`, `RISK:`, `SPLIT:`, or `DONE-PARTIAL:` per `AGENTS.md §10` and stop.
+
+        _Issue auto-seeded from `{t.path.relative_to(ROOT)}` by `seed_issues.py`._
+        """
+    )
+    return out
+
+
+def existing_issue(repo: str, title: str) -> str | None:
+    """Return issue number if an open or recently-closed issue with this exact title exists."""
+    try:
+        out = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "all",
+                "--search",
+                f'"{title}" in:title',
+                "--limit",
+                "5",
+                "--json",
+                "number,title,state,closedAt",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        data = json.loads(out.stdout)
+        for row in data:
+            if row["title"] == title:
+                return str(row["number"])
+    except subprocess.CalledProcessError as e:
+        print(f"[warn] gh issue list failed: {e.stderr}", file=sys.stderr)
+    return None
+
+
+def create_issue(repo: str, task: Task, assign_to: str | None) -> str | None:
+    body = render_body(task, repo)
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        task.title,
+        "--body",
+        body,
+    ]
+    for lbl in task.labels:
+        cmd.extend(["--label", lbl])
+    if assign_to:
+        cmd.extend(["--assignee", assign_to])
+    try:
+        out = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        url = out.stdout.strip()
+        print(f"[created] {task.title} → {url}")
+        return url
+    except subprocess.CalledProcessError as e:
+        print(f"[error] creating {task.title}: {e.stderr}", file=sys.stderr)
+        return None
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--phase", default="all")
+    p.add_argument("--repo", required=True)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--assign-to", default="")
+    args = p.parse_args()
+
+    tasks = discover(args.phase)
+    print(f"Discovered {len(tasks)} task file(s) for phase filter {args.phase!r}")
+
+    created = 0
+    skipped = 0
+    for t in tasks:
+        if existing := existing_issue(args.repo, t.title):
+            print(f"[skip] existing issue #{existing} for {t.title!r}")
+            skipped += 1
+            continue
+        if args.dry_run:
+            print(f"[dry-run] would create: {t.title}")
+            continue
+        if create_issue(args.repo, t, args.assign_to or None):
+            created += 1
+
+    print(f"\nSummary: created={created} skipped-existing={skipped} total-tasks={len(tasks)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The `${DRY_RUN:+--dry-run}` expansion passes `--dry-run` whenever the variable is set (even to the string 'false'). Replaced with `$([ "$DRY_RUN" = "true" ] && echo "--dry-run")` so the flag only passes when the input is literally true.