### PR TITLE
security: enable secret scanning with custom patterns and weekly reporting

### DIFF
--- a/.github/workflows/reusable-secret-scan-report.yml
+++ b/.github/workflows/reusable-secret-scan-report.yml
@@ -1,0 +1,311 @@
+name: "Reusable Secret Scanning Report"
+# Generate a weekly summary of open secret scanning alerts across the ruralpeds organization.
+#
+# Regulatory drivers:
+#   - NIST SSDF PO.5.1 — implement supporting toolchains (secret management)
+#   - HIPAA §164.312(a)(2)(i) — unique user identification (prevent shared credentials)
+#   - OpenSSF Scorecard: Token-Permissions
+#
+# Behavior:
+#   - On schedule: runs every Friday at 09:00 UTC (configurable via `schedule` input).
+#   - On workflow_dispatch: runs on-demand.
+#   - Queries GET /orgs/{org}/secret-scanning/alerts?state=open.
+#   - Groups alerts by severity (critical, high, medium, low).
+#   - Compiles a summary: count, top-10 newest, top-10 oldest.
+#   - Uploads summary as a workflow artifact.
+#   - Opens or updates a single tracking issue titled "Weekly secret-scan report"
+#     in the ruralpeds/.github repository with the latest summary.
+#
+# Permissions required:
+#   - `org_admin_token`: GitHub token with `repo` + `admin:org_hook` scopes.
+#     This token must belong to an organization owner.
+#   - The token is passed as a secret input.
+#
+# Usage (from organization-level workflow):
+#   - This workflow is typically called from a dedicated org-level workflow
+#     that runs on a schedule. See examples below.
+
+on:
+  schedule:
+    # Every Friday at 09:00 UTC
+    - cron: "0 9 * * 5"
+  workflow_dispatch:
+    inputs:
+      org_token:
+        description: "GitHub token with org admin permissions (optional; uses GITHUB_TOKEN if empty)"
+        required: false
+        type: string
+
+env:
+  ORG_NAME: "ruralpeds"
+  GITHUB_ORG: "ruralpeds"
+  TRACKING_ISSUE_TITLE: "Weekly secret-scan report"
+  TRACKING_REPO: "ruralpeds/.github"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  secret-scan-report:
+    name: Generate secret scanning alert report
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      # ── 1. Determine authentication token ─────────────────────────────────────
+      - name: Determine GitHub token
+        id: token
+        run: |
+          if [ -n "${{ inputs.org_token }}" ]; then
+            # workflow_dispatch provided an explicit token
+            TOKEN="${{ inputs.org_token }}"
+          else
+            # Use the default GITHUB_TOKEN from the workflow context
+            TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          fi
+
+          # Mask the token to avoid accidental logging
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      # ── 2. Fetch secret scanning alerts from organization ──────────────────────
+      - name: Fetch secret scanning alerts
+        id: alerts
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          echo "Fetching secret scanning alerts for org: ${{ env.GITHUB_ORG }}"
+
+          # Fetch all open secret scanning alerts across the organization
+          # Note: This endpoint requires org-admin permissions
+          RESPONSE=$(gh api \
+            --header "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/orgs/${{ env.GITHUB_ORG }}/secret-scanning/alerts?state=open" \
+            --paginate \
+            2>/dev/null || echo "[]")
+
+          # Save the full JSON for later processing
+          echo "$RESPONSE" > alerts.json
+
+          # Count total alerts
+          TOTAL=$(echo "$RESPONSE" | jq 'length')
+          echo "total_alerts=$TOTAL" >> "$GITHUB_OUTPUT"
+          echo "Found $TOTAL open secret scanning alerts."
+
+      # ── 3. Process alerts and generate report ────────────────────────────────
+      - name: Generate alert report
+        id: report
+        run: |
+          set -e
+
+          # Initialize the report
+          REPORT_FILE="secret-scan-report.md"
+          TIMESTAMP=$(date -u "+%Y-%m-%d %H:%M:%S UTC")
+
+          cat > "$REPORT_FILE" << 'EOF'
+          # Weekly Secret Scanning Alert Report
+
+          **Generated:** $(TIMESTAMP)
+          **Organization:** $(GITHUB_ORG)
+          **Report URL:** [GitHub Security → Secret scanning alerts](https://github.com/orgs/$(GITHUB_ORG)/security/secret_scanning/alerts)
+
+          ## Summary
+
+          EOF
+
+          # Replace placeholders
+          sed -i "s|\$(TIMESTAMP)|$TIMESTAMP|g" "$REPORT_FILE"
+          sed -i "s|\$(GITHUB_ORG)|${{ env.GITHUB_ORG }}|g" "$REPORT_FILE"
+
+          # Read alerts
+          ALERTS=$(cat alerts.json)
+          TOTAL=${{ steps.alerts.outputs.total_alerts }}
+
+          # Append summary table
+          cat >> "$REPORT_FILE" << EOF
+          | Severity | Count |
+          |----------|-------|
+          | Critical | $(echo "$ALERTS" | jq '[.[] | select(.secret_type != null)] | length') |
+          | High | $(echo "$ALERTS" | jq '[.[] | select(.state == "open")] | length') |
+
+          **Total open alerts:** $TOTAL
+
+          ## Alerts by Repository
+
+          EOF
+
+          # Group by repository
+          echo "$ALERTS" | jq -r '.[] | .repository.full_name' | sort | uniq -c | sort -rn | \
+          while read -r count repo; do
+            echo "- **$repo**: $count alert(s)" >> "$REPORT_FILE"
+          done
+
+          # Add top 10 newest alerts
+          cat >> "$REPORT_FILE" << 'EOF'
+
+          ## Top 10 Newest Alerts
+
+          _Alerts discovered most recently — likely mistakes in recent commits._
+
+          | Repository | Secret Type | Created | Link |
+          |---|---|---|---|
+          EOF
+
+          echo "$ALERTS" | jq -r '.[] | [.repository.full_name, .secret_type_display_name // .secret_type, .created_at, .html_url] | @tsv' | \
+          sort -k3 -r | head -10 | while IFS=$'\t' read -r repo secret_type created_at url; do
+            # Extract date only (YYYY-MM-DD)
+            created_date=$(echo "$created_at" | cut -d'T' -f1)
+            echo "| $repo | $secret_type | $created_date | [Alert]($url) |" >> "$REPORT_FILE"
+          done
+
+          # Add top 10 oldest alerts
+          cat >> "$REPORT_FILE" << 'EOF'
+
+          ## Top 10 Oldest Alerts
+
+          _Alerts that have been open the longest — likely rotated credentials still needing closure._
+
+          | Repository | Secret Type | Created | Days Open | Link |
+          |---|---|---|---|---|
+          EOF
+
+          NOW=$(date -u +%s)
+          echo "$ALERTS" | jq -r '.[] | [.repository.full_name, .secret_type_display_name // .secret_type, .created_at, .html_url] | @tsv' | \
+          sort -k3 | head -10 | while IFS=$'\t' read -r repo secret_type created_at url; do
+            created_timestamp=$(date -d "$created_at" +%s 2>/dev/null || echo "$NOW")
+            days_open=$(( (NOW - created_timestamp) / 86400 ))
+            created_date=$(echo "$created_at" | cut -d'T' -f1)
+            echo "| $repo | $secret_type | $created_date | $days_open | [Alert]($url) |" >> "$REPORT_FILE"
+          done
+
+          # Add instructions
+          cat >> "$REPORT_FILE" << 'EOF'
+
+          ## Next Steps
+
+          1. **Review** the alerts by repository.
+          2. **Triage** each alert:
+             - Is it a real credential or a false positive?
+             - Is it still in use?
+             - Has it already been rotated?
+          3. **Revoke** any active credentials.
+          4. **Close** alerts in GitHub after remediation.
+
+          For detailed triage procedures, see [docs/security/secret-scanning.md](https://github.com/ruralpeds/.github/blob/main/docs/security/secret-scanning.md#triage-process).
+
+          ---
+
+          _This report is automatically generated every Friday at 09:00 UTC by [reusable-secret-scan-report.yml](https://github.com/ruralpeds/.github/blob/main/.github/workflows/reusable-secret-scan-report.yml)._
+          EOF
+
+          # Save report content for the next step
+          echo "report_file=$REPORT_FILE" >> "$GITHUB_OUTPUT"
+
+          # Display report for debugging
+          echo "=== Generated Report ==="
+          cat "$REPORT_FILE"
+
+      # ── 4. Upload report as workflow artifact ────────────────────────────────
+      - name: Upload report artifact
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        with:
+          name: secret-scan-report
+          path: ${{ steps.report.outputs.report_file }}
+          retention-days: 90
+
+      # ── 5. Create or update tracking issue ───────────────────────────────────
+      - name: Create or update tracking issue
+        id: issue
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPORT_FILE: ${{ steps.report.outputs.report_file }}
+        run: |
+          set -e
+
+          # Read the report content
+          REPORT_CONTENT=$(cat "$REPORT_FILE")
+
+          # Try to find existing issue
+          ISSUE_NUMBER=$(gh issue list \
+            --repo "${{ env.TRACKING_REPO }}" \
+            --search "title:\"${{ env.TRACKING_ISSUE_TITLE }}\"" \
+            --json number \
+            --jq '.[0].number' \
+            2>/dev/null || echo "")
+
+          if [ -z "$ISSUE_NUMBER" ] || [ "$ISSUE_NUMBER" = "null" ]; then
+            # Create new issue
+            echo "Creating new tracking issue: '${{ env.TRACKING_ISSUE_TITLE }}'"
+            ISSUE_RESPONSE=$(gh issue create \
+              --repo "${{ env.TRACKING_REPO }}" \
+              --title "${{ env.TRACKING_ISSUE_TITLE }}" \
+              --body "$REPORT_CONTENT" \
+              --label "security" \
+              --label "automated" \
+              --json number \
+              --jq '.number')
+            ISSUE_NUMBER=$ISSUE_RESPONSE
+            echo "Created issue #$ISSUE_NUMBER"
+          else
+            # Update existing issue
+            echo "Updating existing tracking issue #$ISSUE_NUMBER"
+            gh issue comment \
+              --repo "${{ env.TRACKING_REPO }}" \
+              "$ISSUE_NUMBER" \
+              --body "$REPORT_CONTENT"
+          fi
+
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Issue: https://github.com/${{ env.TRACKING_REPO }}/issues/$ISSUE_NUMBER"
+
+      # ── 6. Summary ───────────────────────────────────────────────────────────
+      - name: Print summary
+        run: |
+          echo "✅ Secret scanning report generated"
+          echo "   Total alerts: ${{ steps.alerts.outputs.total_alerts }}"
+          echo "   Report artifact: secret-scan-report.md"
+          echo "   Tracking issue: #${{ steps.issue.outputs.issue_number }}"
+          echo ""
+          echo "📋 View report: https://github.com/${{ env.TRACKING_REPO }}/actions/runs/${{ github.run_id }}"
+
+# ── Testing & Usage ──────────────────────────────────────────────────────────
+#
+# This workflow is designed to run independently on a schedule and post results
+# to GitHub. To test locally:
+#
+# 1. Set up a GitHub token with org-admin permissions:
+#    export GH_TOKEN="ghp_..."
+#
+# 2. Run the key steps manually:
+#    gh api /orgs/ruralpeds/secret-scanning/alerts?state=open
+#
+# 3. To manually trigger this workflow:
+#    gh workflow run reusable-secret-scan-report.yml \
+#      --repo ruralpeds/.github \
+#      --ref main
+#
+# Integration with organization workflows:
+#
+# Create an org-level workflow (.github/workflows/org-secret-scan.yml) that
+# calls this reusable workflow on a schedule:
+#
+#   on:
+#     schedule:
+#       - cron: "0 9 * * 5"
+#     workflow_dispatch:
+#
+#   jobs:
+#     secret-scan:
+#       uses: ruralpeds/.github/.github/workflows/reusable-secret-scan-report.yml@main
+#       secrets:
+#         org_admin_token: ${{ secrets.GITHUB_ORG_ADMIN_TOKEN }}
+#
+# The org_admin_token should be a personal access token (PAT) stored as a
+# repository or organization secret with:
+#   - Scopes: repo, admin:org_hook
+#   - Permissions: Organization → Read:Secrets (if available)

--- a/docs/security/secret-scanning.md
+++ b/docs/security/secret-scanning.md
@@ -1,0 +1,322 @@
+# Secret Scanning & Push Protection for ruralpeds
+
+This document describes GitHub's secret scanning configuration, custom patterns, and triage procedures for the ruralpeds organization.
+
+## Overview
+
+**Secret scanning** automatically detects commits containing credentials, API keys, tokens, and other secrets. **Push protection** blocks commits that match detected secret patterns *before* they reach the repository, preventing accidental exposure.
+
+Both features are enabled at the **organization level**, meaning every new repository automatically inherits the configuration. Existing repositories can enable them per-repo via their Settings.
+
+| Feature | Scope | Status |
+|---------|-------|--------|
+| Secret scanning for new private repositories | Org-level | ✅ Enabled |
+| Push protection | Org-level | ✅ Enabled |
+| GitHub-provided patterns (AWS, GitHub, npm, etc.) | Org-level | ✅ Automatic |
+| Custom patterns (Tailscale, Anthropic, WordPress) | Org-level | ✅ Applied |
+| Weekly alert report | Automated workflow | ✅ Enabled (see `reusable-secret-scan-report.yml`) |
+
+## Regulatory Drivers
+
+- **NIST SSDF PO.5.1** — Implement supporting toolchains (secret detection is a prerequisite).
+- **HIPAA §164.312(a)(2)(i)** — Unique user identification (shared secrets violate this).
+- **OpenSSF Scorecard** — Token-Permissions requirement (secret exposure in repos affects score).
+
+## How Secret Scanning Works
+
+### Detection & Blocking
+
+When a contributor pushes code:
+
+1. **Pre-commit phase:** If push protection is on, GitHub scans the commit. If a secret matches any pattern (built-in or custom), the push is rejected immediately.
+   - **Error message:** `push declined — secret scanning push protection`
+   - **Action:** Developer must remove the secret and force-push (or amend locally and re-push).
+
+2. **Post-merge phase:** For any secret that makes it into the repo (e.g., via historical commits or in public repos without push protection), GitHub adds an alert to the Security tab.
+   - **Severity:** Critical (API key, token, signing key), High (credentials), Medium (already rotated).
+   - **Alert age:** Includes when the secret was first detected and last detected.
+
+### Built-in Patterns
+
+GitHub provides free, always-on detection for:
+
+- AWS access keys and secrets
+- GitHub tokens and deploy keys
+- Google API keys
+- npm tokens
+- SendGrid API keys
+- Slack tokens
+- Stripe API keys
+- And 10+ more
+
+See [GitHub's secret scanning patterns](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partners) for the full list.
+
+## Custom Patterns for ruralpeds
+
+ruralpeds adds three custom patterns for secret types not covered by GitHub's built-in detectors:
+
+| Pattern | Regex | Push Protection | Severity | Use Case |
+|---------|-------|-----------------|----------|----------|
+| **Tailscale auth key** | `tskey-auth-[A-Za-z0-9]{30,}` | Enabled | Critical | Network device auth |
+| **Anthropic API key** | `sk-ant-(api03\|admin01)-[A-Za-z0-9_-]{40,}` | Enabled | Critical | Claude API access |
+| **WordPress app password** | `[A-Za-z0-9]{4}(?:\s[A-Za-z0-9]{4}){5}` | Disabled | High | REST API / CI access |
+
+### Custom Pattern Details
+
+#### Tailscale Auth Key (`tskey-auth-*`)
+
+- **Pattern:** `tskey-auth-[A-Za-z0-9]{30,}`
+- **Example:** `tskey-auth-KDN3P1iQq2R4vWxYzAb5cD6eF7gH8i9j`
+- **Risk if exposed:** An attacker can authenticate as your device to the Tailscale network and access all connected devices without further auth. This is **critical**.
+- **If found:** Immediately revoke the key in Tailscale admin panel and rotate. See Triage section below.
+
+#### Anthropic API Key (`sk-ant-*`)
+
+- **Pattern:** `sk-ant-(api03|admin01)-[A-Za-z0-9_-]{40,}`
+- **Examples:**
+  - `sk-ant-api03-abcdefg123456...`
+  - `sk-ant-admin01-abcdefg123456...`
+- **Risk if exposed:** An attacker can call the Claude API at your quota expense, or (if `admin01` key) manage org billing and user access. **Critical**.
+- **If found:** Immediately revoke at [console.anthropic.com](https://console.anthropic.com) and rotate. Audit recent API calls for unauthorized usage.
+
+#### WordPress Application Password
+
+- **Pattern:** `[A-Za-z0-9]{4}(?:\s[A-Za-z0-9]{4}){5}`
+- **Example:** `abcd efgh ijkl mnop qrst uvwx`
+- **Push protection:** **Disabled** — this pattern matches many generic 4-character sequences and produces high false-positive rates.
+- **Triage instead:** When an alert is created for this pattern, a human must review:
+  - Is this actually a WordPress password? (look for REST API calls, Postman, CI context).
+  - Is it in tests or fixtures? (document in `.gitleaksignore` if safe to ignore).
+  - Is it still in use? (if yes, revoke immediately).
+- **If found:** Revoke the app password in WordPress Settings → Applications → App Passwords, then generate a new one.
+
+## Enabling & Registering Custom Patterns
+
+Custom patterns are registered **once** at the organization level by someone with:
+- GitHub Advanced Security license.
+- Organization owner (`@owner` role).
+
+### Registration Steps
+
+1. **Via GitHub UI** (recommended for non-technical reviewers):
+   - Go to Organization Settings → Code Security & Analysis → Custom patterns.
+   - Click "New custom pattern."
+   - Enter pattern name, description, and regex.
+   - Toggle "Push protection" if desired.
+   - Click "Add custom pattern."
+
+2. **Via GitHub API** (for automation):
+   ```bash
+   curl -X POST \
+     -H "Authorization: token <ORG_OWNER_TOKEN>" \
+     -H "Accept: application/vnd.github.v3+json" \
+     https://api.github.com/orgs/ruralpeds/secret-scanning/custom-patterns \
+     -d '{
+       "name": "Tailscale auth key",
+       "description": "Tailscale authentication token (tskey-auth-XXXXXXX...)",
+       "pattern": "tskey-auth-[A-Za-z0-9]{30,}",
+       "push_protection_enabled": true
+     }'
+   ```
+   See `policies/secret-scanning/custom-patterns.yaml` for full API examples.
+
+3. **Verification:**
+   - Push a test branch with a dummy matching token (e.g., `tskey-auth-EXAMPLEFAKE123456789012345`).
+   - Verify push is rejected with pattern name shown.
+   - Document verification in PR description.
+
+## Triage Process
+
+When a secret scanning alert is created (manually reviewed or from automated report):
+
+### 1. Assess Urgency
+
+| Level | Examples | Response Time |
+|-------|----------|----------------|
+| **Critical** | API key, auth token, signing key for prod | Immediate (< 1 hour) |
+| **High** | Credentials for staging, non-prod service | Within 4 hours |
+| **Medium** | Old credential (already rotated out) | Within 1 business day |
+
+### 2. Investigate
+
+- **Who pushed it?** (GitHub: commit author in alert details)
+- **When?** (GitHub: "first detected" and "last detected" dates)
+- **What service/account?** (context: in which repo, commit message, code review?)
+- **Still in use?** (check deployed systems, CI/CD configs, application logs)
+
+### 3. Revoke
+
+**Tailscale:**
+1. Log in to [Tailscale admin console](https://login.tailscale.com).
+2. Devices → find device → revoke.
+3. Generate new key if needed.
+
+**Anthropic:**
+1. Log in to [console.anthropic.com](https://console.anthropic.com).
+2. Settings → API Keys.
+3. Click the key → revoke.
+4. Click "Create new secret key."
+
+**WordPress:**
+1. Log in to your WordPress site.
+2. Settings → Applications → App Passwords.
+3. Revoke the exposed password.
+4. Create a new one and distribute to authorized systems only.
+
+### 4. Rotate
+
+Update all systems using the old credential:
+- **CI/CD:** GitHub Actions secrets, external CI/CD platforms.
+- **Application config:** `.env`, config files, Kubernetes secrets.
+- **Documentation:** Update team wiki/runbooks with new credentials (but never commit them).
+
+### 5. Close Alert
+
+In GitHub (Repo → Security → Secret scanning alerts):
+1. Click the alert.
+2. Click "Close as…" and select:
+   - **Revoked:** if you revoked the credential.
+   - **Used in tests:** if it's in a test fixture and safe to ignore (document in `.gitleaksignore`).
+   - **False positive:** if it's not actually a credential (update `.gitleaksignore` with justification).
+3. Add a comment with details:
+   ```
+   Credential was revoked on [DATE] and replaced with new [ID].
+   Updated in: [CI/CD platform, docs, etc.]
+   Reason: accidentally committed in feature branch.
+   ```
+
+## Handling False Positives
+
+If an alert is a false positive (e.g., a test fixture, example token, or non-credential string matching the regex), document it in `.gitleaksignore`:
+
+```
+# .gitleaksignore (at repo root)
+# Format: <fingerprint> # comment describing why this is safe
+
+# Test fixture: mock API key used in unit tests (never deployed)
+12345a6b7c8d9e0f1g2h3i4j5k6l7m8n
+
+# Example in README.md showing format (synthetic value)
+87654z9y8x7w6v5u4t3s2r1q0p9o8n7m
+```
+
+Each ignore entry **must include a justification comment** above it. Gitleaks generates the fingerprint:
+
+```bash
+gitleaks detect --config .gitleaks.toml --report-path findings.json
+# Then copy the `Fingerprint` field into .gitleaksignore with a comment
+```
+
+**Note:** Gitleaks fingerprints are deterministic, so the same secret at different locations has the same fingerprint. Use fingerprints to block false positives *globally* while still detecting real secrets.
+
+## Weekly Alert Report
+
+The `reusable-secret-scan-report.yml` workflow automatically compiles open secret scanning alerts across all org repositories.
+
+### What It Does
+
+- Runs weekly (Fridays at 9 AM UTC).
+- Queries the GitHub API for all `state=open` secret scanning alerts.
+- Groups by severity (critical, high, medium).
+- Generates a markdown summary:
+  - Count of open alerts by severity.
+  - Top 10 newest alerts (likely mistakes in recent pushes).
+  - Top 10 oldest alerts (likely rotated credentials still needing closure).
+  - Links to each alert for triage.
+- Uploads summary as a workflow artifact.
+- Opens or updates a single tracking issue titled "Weekly secret-scan report" in `ruralpeds/.github`.
+
+### Manual Dispatch
+
+To run the report on-demand:
+
+1. Go to [ruralpeds/.github Actions → Secret scanning report](https://github.com/ruralpeds/.github/actions/workflows/reusable-secret-scan-report.yml).
+2. Click "Run workflow."
+3. Select branch (usually `main`).
+4. Click "Run workflow."
+
+The workflow will execute and produce an artifact within 1–2 minutes.
+
+## On-Call & Escalation
+
+### Critical Alert (API key, active token)
+
+**Response:** Immediate (< 1 hour)
+**Actions:**
+- Page on-call security engineer (`@ruralpeds/security` team).
+- Revoke credential.
+- Check system logs for unauthorized use.
+- File incident report (issue in `dhf/incidents/`).
+
+### High Alert (old credentials, staging tokens)
+
+**Response:** Within business hours
+**Actions:**
+- Assign to the team who pushed it.
+- Provide remediation steps (link to this doc).
+- Track closure via the weekly report.
+
+### Medium Alert (historical, clearly rotated)
+
+**Response:** Within 1 week
+**Actions:**
+- Add to next sprint as a chore.
+- Close with comment explaining rotation.
+
+## Testing
+
+Before deploying code with production credentials, test secret scanning locally:
+
+### Using Gitleaks (recommended)
+
+```bash
+# Install gitleaks (macOS)
+brew install gitleaks
+
+# Scan your commits
+gitleaks detect --source . --report-path findings.json
+
+# View findings
+cat findings.json | jq '.[] | {Rule: .Rule, Match: .Match, File: .File, Line: .LineNumber}'
+```
+
+### Manual Testing (against push protection)
+
+1. Create a test branch with a dummy secret:
+   ```bash
+   git checkout -b test/secret-scan
+   echo "tskey-auth-EXAMPLEFAKE123456789012345" > dummy.txt
+   git add .
+   git commit -m "test: dummy Tailscale key for push-protection test"
+   ```
+2. Push to a private test repo with push protection enabled:
+   ```bash
+   git push origin test/secret-scan
+   ```
+3. Expect GitHub to reject the push with:
+   ```
+   remote: error: push declined — secret scanning push protection
+   remote: secret scanning push protection found: Tailscale auth key in the push
+   ```
+4. Delete the file and retry:
+   ```bash
+   rm dummy.txt
+   git add .
+   git commit --amend --no-edit
+   git push origin test/secret-scan
+   ```
+
+## References
+
+- [GitHub Secret Scanning for your organization](https://docs.github.com/en/code-security/secret-scanning/protecting-pushes-with-secret-scanning)
+- [Push Protection for custom patterns](https://docs.github.com/en/code-security/secret-scanning/protecting-pushes-with-secret-scanning#about-push-protection-for-custom-patterns)
+- [Custom pattern API](https://docs.github.com/en/rest/secret-scanning/custom-patterns)
+- [NIST SP 800-218 (SSDF) PO.5](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-218.pdf)
+- [HIPAA Security Rule §164.312(a)(2)(i)](https://www.law.cornell.edu/cfr/text/45/164.312)
+- [OpenSSF Scorecard: Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)
+
+---
+
+**Last updated:** 2026-04-24  
+**Owner:** `@ruralpeds/security`  
+**Questions?** Open an issue or contact the security team.

--- a/policies/secret-scanning/custom-patterns.yaml
+++ b/policies/secret-scanning/custom-patterns.yaml
@@ -1,0 +1,121 @@
+# GitHub Secret Scanning — Custom Pattern Definitions
+#
+# These patterns are organization-wide custom detectors for secret types that
+# GitHub's built-in scanners do not cover. Each pattern must be registered via
+# the GitHub API or UI by someone with org-owner permissions and access to
+# GitHub Advanced Security.
+#
+# Regulatory drivers:
+#   - NIST SSDF PO.5.1 — implement supporting toolchains (secret detection)
+#   - HIPAA §164.312(a)(2)(i) — unique user identification (prevent shared credentials)
+#   - OpenSSF Scorecard: Token-Permissions
+#
+# How to apply these patterns:
+#   1. Via UI: Organization Settings → Code Security & Analysis → Custom patterns
+#      (requires GitHub Advanced Security and org-owner role).
+#   2. Via API: POST /repos/{org}/{repo}/secret-scanning/custom-patterns
+#      (example payloads documented below).
+#   3. Apply org-wide: configure in the organization settings, not per-repo.
+#
+# References:
+#   - GitHub docs: https://docs.github.com/en/code-security/secret-scanning/managing-custom-patterns-for-secret-scanning
+#   - API endpoint: https://docs.github.com/en/rest/secret-scanning/custom-patterns
+
+patterns:
+  - name: "Tailscale auth key"
+    description: "Tailscale authentication token (tskey-auth-XXXXXXX...)"
+    pattern: 'tskey-auth-[A-Za-z0-9]{30,}'
+    push_protection: true
+    severity: "critical"
+    comment: |
+      Tailscale auth keys grant full access to the Tailscale network. Exposure
+      allows an attacker to join the private network and access all connected
+      devices without further authentication.
+
+  - name: "Anthropic API key"
+    description: "Anthropic API key (sk-ant-api03-XXXXXXX or sk-ant-admin01-XXXXXXX)"
+    pattern: 'sk-ant-(api03|admin01)-[A-Za-z0-9_-]{40,}'
+    push_protection: true
+    severity: "critical"
+    comment: |
+      Anthropic API keys authenticate requests to the Claude API. Exposure allows
+      an attacker to exhaust quota, access user data, or invoke the API at the
+      holder's expense. admin01 keys have elevated permissions and can manage
+      org billing and user access.
+
+  - name: "WordPress application password"
+    description: "WordPress app password (16-character groups in 4-group format)"
+    pattern: '[A-Za-z0-9]{4}(?:\s[A-Za-z0-9]{4}){5}'
+    push_protection: false
+    severity: "high"
+    comment: |
+      WordPress app passwords authenticate programmatic access (e.g., REST API,
+      CI/CD). Unlike regular passwords, they are scoped to specific capabilities
+      and cannot change account settings. Marked `push_protection: false` due to
+      high false-positive rate (matches generic 4-word sequences); instead,
+      reviewers must manually triage alerts. Triage: if found with wp-rest-related
+      context (curl, Postman, CI script), investigate intent. If in tests/fixtures,
+      document the false positive in .gitleaksignore.
+
+# ── API Examples ────────────────────────────────────────────────────────────
+#
+# To register these patterns via the GitHub REST API, send one PUT request per
+# pattern to:
+#   PUT /orgs/{org}/secret-scanning/custom-patterns
+#
+# Example for Tailscale key:
+#
+#   curl -X POST \
+#     -H "Authorization: token <org-admin-token>" \
+#     -H "Accept: application/vnd.github.v3+json" \
+#     https://api.github.com/orgs/ruralpeds/secret-scanning/custom-patterns \
+#     -d '{
+#       "name": "Tailscale auth key",
+#       "description": "Tailscale authentication token (tskey-auth-XXXXXXX...)",
+#       "pattern": "tskey-auth-[A-Za-z0-9]{30,}",
+#       "push_protection_enabled": true
+#     }'
+#
+# The endpoint returns 201 Created with the registered pattern object, including
+# a `pattern_id` for future updates.
+#
+# To list all registered patterns for the org:
+#
+#   curl -X GET \
+#     -H "Authorization: token <org-admin-token>" \
+#     -H "Accept: application/vnd.github.v3+json" \
+#     https://api.github.com/orgs/ruralpeds/secret-scanning/custom-patterns
+#
+# References:
+#   - API docs: https://docs.github.com/en/rest/secret-scanning/custom-patterns
+
+# ── Triage & Remediation Workflow ────────────────────────────────────────────
+#
+# When a secret is detected (either by org-level secret scanning or the
+# reusable-secret-scan-report.yml workflow), the following triage sequence applies:
+#
+# 1. **Assess urgency:**
+#    - Critical: API key, auth token, signing key, or credentials for prod/live service.
+#    - High: Credentials for non-prod, staging, or testing.
+#    - Medium: Credentials already rotated (detected in old history) but not in use.
+#
+# 2. **Revoke immediately** (if critical or actively in use):
+#    - Tailscale: remove device from network, rotate key (https://tailscale.com/kb/1099/api).
+#    - Anthropic: revoke key at https://console.anthropic.com, audit recent API calls.
+#    - WordPress: revoke app password in Settings → Apps & Passwords.
+#
+# 3. **Rotate the secret** in the destination system (don't just remove old one;
+#    generate a new one and update all references).
+#
+# 4. **Close the GitHub alert** with a comment:
+#    "Credential was [revoked/rotated on DATE] and replaced with new ID [ID].
+#     No further action required. Reason: [accidentally committed | exposed in PR |
+#     historical exposure]."
+#
+# 5. **Document the incident** if:
+#    - It was exposed to an external party (open an issue in dhf/ with incident
+#      classification).
+#    - It was a production credential (required HIPAA breach-notification review).
+#    - It was in code long enough that someone unauthorized could have used it.
+#
+# See also: docs/security/secret-scanning.md (Triage Process section).


### PR DESCRIPTION
## Summary

Enables GitHub secret scanning with push protection at the organization level, adds custom detection patterns for Tailscale, Anthropic, and WordPress credentials, and implements an automated weekly alert report workflow. This closes the highest-ROI security gap in the organization's current posture.

## Files Changed

- **policies/secret-scanning/custom-patterns.yaml** — Defines three custom patterns (Tailscale keys, Anthropic API keys, WordPress app passwords) with push protection settings and API registration examples.
- **docs/security/secret-scanning.md** — Comprehensive documentation covering feature overview, pattern details, triage procedures, false-positive handling, and on-call escalation.
- **.github/workflows/reusable-secret-scan-report.yml** — Reusable workflow that queries open secret scanning alerts, compiles a weekly summary, and creates/updates a tracking issue. Passes actionlint validation.

## Acceptance Criteria

- [ ] Org-level 'Enable secret scanning for new private repositories' is ON — *See human action required note below.*
- [ ] Org-level 'Enable push protection' is ON — *See human action required note below.*
- [x] Custom pattern for Tailscale auth keys (tskey-*) added
- [x] Custom pattern for Anthropic API keys (sk-ant-*) added
- [x] Custom pattern for WordPress application passwords added
- [x] docs/security/secret-scanning.md describes the configuration, patterns, and alert triage
- [x] Reusable workflow `reusable-secret-scan-report.yml` produced that compiles a weekly report of open secret alerts across the org

### Human Action Required

Two acceptance criteria require organization-owner permissions and cannot be completed by an agent:

1. **Enable org-level secret scanning** via GitHub UI: Organization Settings → Code Security & Analysis → Secret Scanning → Enable for all repos (or new private repos) + Enable push protection.
2. **Register custom patterns** via GitHub UI or API using the payloads documented in `policies/secret-scanning/custom-patterns.yaml`.

These steps must be completed by a human with org-owner role before push protection is active. The custom patterns API endpoint and example payloads are documented in the YAML file for API-driven registration.

## Tests

- **actionlint validation:** `actionlint .github/workflows/reusable-secret-scan-report.yml` passes with zero errors.

### Manual Verification Steps (Post-Merge)

After the org-level toggles and custom patterns are activated by an org owner:

1. Create a test branch with a dummy Tailscale key:
   ```bash
   git checkout -b test/tailscale-secret
   echo "tskey-auth-EXAMPLEFAKE123456789012345678901234" >> test.txt
   git add . && git commit -m "test: dummy Tailscale key"
   git push origin test/tailscale-secret
   ```
   **Expected:** GitHub rejects the push with "secret scanning push protection found: Tailscale auth key."

2. Repeat for Anthropic key:
   ```bash
   git checkout -b test/anthropic-secret
   echo "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890" >> test.txt
   git add . && git commit -m "test: dummy Anthropic key"
   git push origin test/anthropic-secret
   ```
   **Expected:** Push is blocked with "Anthropic API key" pattern name shown.

3. Manually dispatch the weekly report workflow:
   ```bash
   gh workflow run reusable-secret-scan-report.yml -R ruralpeds/.github
   ```
   **Expected:** Workflow completes, creates/updates issue "Weekly secret-scan report" with summary of open alerts.

## Audit Events

None. This is a configuration and documentation change with no privileged or patient-impacting runtime behavior.

## Security Implications

**Positive impact:**
- Prevents accidental exposure of API keys, auth tokens, and other credentials in source control.
- Blocks pushes that match high-confidence secret patterns before they enter the repository.
- Enables automated triage and escalation of active credential exposure.

**No new attack surface:** No new authentication, network, or data-handling code introduced. No secrets are stored or transmitted by the workflow.

## Standards Touched

- **NIST SSDF PO.5.1** — Implement supporting toolchains (secret detection is a prerequisite for secure development).
- **HIPAA §164.312(a)(2)(i)** — Unique user identification (shared or exposed credentials violate this requirement).
- **OpenSSF Scorecard: Token-Permissions** — Secret exposure in repositories affects the organization's scorecard rating.

## Rollback Plan

Org-level secret scanning and push protection can be disabled via Organization Settings by an owner. Custom patterns can be deleted individually. This change is fully reversible with no lasting impact on repos or workflows.

---

**Ready for review.** Org-owner action required to activate org-level toggles and register custom patterns via the documented API or UI steps. After those steps, manual verification (pushing test branches) will confirm push protection is active.