### PR TITLE
ci: migrate SDLC gate workflows to self-hosted macOS runners

### DIFF
--- a/.github/workflows/01-build-and-test.yml
+++ b/.github/workflows/01-build-and-test.yml
@@ -29,7 +29,8 @@ jobs:
   # =========================================================================
   code-review:
     name: Code Review & Design Verification
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -68,7 +69,8 @@ jobs:
   # =========================================================================
   unit-tests:
     name: Unit Tests (≥80% Coverage)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 30
     permissions:
       contents: read
       checks: write
@@ -124,7 +126,8 @@ jobs:
   # =========================================================================
   static-analysis:
     name: Static Analysis (Linting, Type Checking)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 20
     permissions:
       contents: read
       security-events: write
@@ -180,7 +183,8 @@ jobs:
   # =========================================================================
   dependency-check:
     name: Dependency Security Scanning
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 20
     permissions:
       contents: read
       security-events: write
@@ -215,73 +219,73 @@ jobs:
 
   # =========================================================================
   # Database Migration Validation
+  # macOS self-hosted: Docker service containers aren't supported, so we
+  # start PostgreSQL via docker run and clean up in the final step.
   # =========================================================================
   database-validation:
     name: Database Migration Validation
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:15-alpine
-        env:
-          POSTGRES_USER: audit_trail_user
-          POSTGRES_PASSWORD: test_password
-          POSTGRES_DB: audit_trail
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Start PostgreSQL
+        run: |
+          docker rm -f postgres-test 2>/dev/null || true
+          docker run -d --name postgres-test \
+            -e POSTGRES_USER=audit_trail_user \
+            -e POSTGRES_PASSWORD=test_password \
+            -e POSTGRES_DB=audit_trail \
+            -p 5432:5432 \
+            postgres:15-alpine
+          echo "Waiting for PostgreSQL to be ready..."
+          for i in $(seq 1 30); do
+            docker exec postgres-test pg_isready -U audit_trail_user && break
+            sleep 2
+          done
+
       - name: Validate database migrations
         run: |
           echo "🗄️  SDLC Gate 2: Database Migration Validation"
 
-          # Install PostgreSQL client
-          sudo apt-get install -y postgresql-client
-
-          # Run all migrations
+          # Run all migrations via docker exec
           for migration in infrastructure/database/*.sql; do
             echo "  Running: $(basename $migration)"
-            psql -h localhost -U audit_trail_user -d audit_trail \
-              -f "$migration" 2>&1 | tee -a migration.log
+            docker exec -i postgres-test psql -U audit_trail_user -d audit_trail \
+              < "$migration" 2>&1 | tee -a migration.log
           done
 
           # Verify audit trail table structure
-          psql -h localhost -U audit_trail_user -d audit_trail <<EOF
-          -- Verify immutability constraint
-          SELECT COUNT(*) FROM information_schema.check_constraints
-          WHERE table_name='audit_trail' AND constraint_name LIKE '%immutable%';
+          docker exec postgres-test psql -U audit_trail_user -d audit_trail -c "
+            SELECT COUNT(*) AS immutable_constraints
+            FROM information_schema.check_constraints
+            WHERE table_name='audit_trail' AND constraint_name LIKE '%immutable%';
 
-          -- Verify required columns
-          SELECT COUNT(*) FROM information_schema.columns
-          WHERE table_name='audit_trail' AND column_name IN
-          ('event_id', 'merkle_chain_hash', 'signature', 'digital_signature');
+            SELECT COUNT(*) AS required_columns
+            FROM information_schema.columns
+            WHERE table_name='audit_trail'
+              AND column_name IN ('event_id','merkle_chain_hash','signature','digital_signature');
 
-          -- Verify audit trail access permissions
-          SELECT grantee, privilege_type FROM information_schema.role_table_grants
-          WHERE table_name='audit_trail';
-          EOF
+            SELECT grantee, privilege_type
+            FROM information_schema.role_table_grants
+            WHERE table_name='audit_trail';
+          "
 
           echo "✅ Database migrations validated"
 
-        env:
-          PGHOST: localhost
-          PGUSER: audit_trail_user
-          PGPASSWORD: test_password
-          PGDATABASE: audit_trail
+      - name: Stop PostgreSQL
+        if: always()
+        run: docker rm -f postgres-test || true
 
   # =========================================================================
   # Build Summary
   # =========================================================================
   build-summary:
     name: Build Summary (Gate 2 Complete)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 5
     needs: [code-review, unit-tests, static-analysis, dependency-check, database-validation]
     if: always()
 

--- a/.github/workflows/02-integration-system-tests.yml
+++ b/.github/workflows/02-integration-system-tests.yml
@@ -20,42 +20,47 @@ env:
 jobs:
   # =========================================================================
   # Gate 3: Integration Tests
+  # macOS self-hosted: Docker service containers aren't supported, so we
+  # start PostgreSQL and Redis via docker run and clean up at the end.
   # =========================================================================
   integration-tests:
     name: Integration Tests (API + Database)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: read
 
-    services:
-      postgres:
-        image: postgres:15-alpine
-        env:
-          POSTGRES_USER: audit_trail_user
-          POSTGRES_PASSWORD: test_password
-          POSTGRES_DB: audit_trail
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-      redis:
-        image: redis:7-alpine
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 6379:6379
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Start services (PostgreSQL + Redis)
+        run: |
+          docker rm -f pg-test redis-test 2>/dev/null || true
+
+          docker run -d --name pg-test \
+            -e POSTGRES_USER=audit_trail_user \
+            -e POSTGRES_PASSWORD=test_password \
+            -e POSTGRES_DB=audit_trail \
+            -p 5432:5432 \
+            postgres:15-alpine
+
+          docker run -d --name redis-test \
+            -p 6379:6379 \
+            redis:7-alpine
+
+          echo "Waiting for PostgreSQL..."
+          for i in $(seq 1 30); do
+            docker exec pg-test pg_isready -U audit_trail_user && break
+            sleep 2
+          done
+
+          echo "Waiting for Redis..."
+          for i in $(seq 1 15); do
+            docker exec redis-test redis-cli ping | grep -q PONG && break
+            sleep 2
+          done
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -70,13 +75,10 @@ jobs:
 
       - name: Initialize database schema
         run: |
-          # Run all migrations
           for migration in infrastructure/database/*.sql; do
-            psql -h localhost -U audit_trail_user -d audit_trail \
-              -f "$migration" > /dev/null 2>&1
+            docker exec -i pg-test psql -U audit_trail_user -d audit_trail \
+              < "$migration" > /dev/null 2>&1
           done
-        env:
-          PGPASSWORD: test_password
 
       - name: Run integration tests
         run: |
@@ -103,39 +105,38 @@ jobs:
         run: |
           echo "🔐 Verify audit trail immutability and chain integrity"
 
-          # Test 1: Verify immutability constraint
-          psql -h localhost -U audit_trail_user -d audit_trail <<EOF
-          -- Insert test event
-          INSERT INTO audit_trail (
-            event_id, timestamp, unix_timestamp, user_id, action_type,
-            resource_type, resource_id, event_json, event_hash,
-            signature, signature_timestamp, merkle_chain_hash
-          ) VALUES (
-            'TEST-INT-001', NOW(), EXTRACT(EPOCH FROM NOW())::BIGINT, 'test_user',
-            'integration_test', 'TEST', 'test-id-001',
-            '{"test":"data"}', 'hash123',
-            'signature123', NOW(), 'merkle123'
-          );
+          docker exec pg-test psql -U audit_trail_user -d audit_trail -c "
+            INSERT INTO audit_trail (
+              event_id, timestamp, unix_timestamp, user_id, action_type,
+              resource_type, resource_id, event_json, event_hash,
+              signature, signature_timestamp, merkle_chain_hash
+            ) VALUES (
+              'TEST-INT-001', NOW(), EXTRACT(EPOCH FROM NOW())::BIGINT, 'test_user',
+              'integration_test', 'TEST', 'test-id-001',
+              '{\"test\":\"data\"}', 'hash123',
+              'signature123', NOW(), 'merkle123'
+            );
+          "
 
-          -- Attempt DELETE (should fail)
-          \set QUIET_MESSAGE 1
-          DELETE FROM audit_trail WHERE event_id='TEST-INT-001';
-          \set QUIET_MESSAGE 0
+          # Attempt DELETE (should fail due to immutability constraint)
+          docker exec pg-test psql -U audit_trail_user -d audit_trail -c \
+            "DELETE FROM audit_trail WHERE event_id='TEST-INT-001';" 2>&1 || true
 
-          -- Verify event still exists
-          SELECT COUNT(*) as event_count FROM audit_trail
-          WHERE event_id='TEST-INT-001';
-          EOF
+          # Verify event still exists
+          docker exec pg-test psql -U audit_trail_user -d audit_trail -c \
+            "SELECT COUNT(*) AS event_count FROM audit_trail WHERE event_id='TEST-INT-001';"
 
-        env:
-          PGPASSWORD: test_password
+      - name: Stop services
+        if: always()
+        run: docker rm -f pg-test redis-test || true
 
   # =========================================================================
   # Gate 4: System Tests & Compliance Verification
   # =========================================================================
   system-tests:
     name: System Tests (FHIR, EHR Integration)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: read
@@ -167,15 +168,12 @@ jobs:
         run: |
           echo "📋 FHIR US Core 6.1 Conformance Validation"
 
-          # Test: FHIR patient resource
           python -m pytest tests/system/test_fhir_compliance.py::TestFHIRPatient \
             -v
 
-          # Test: FHIR observation (vitals)
           python -m pytest tests/system/test_fhir_compliance.py::TestFHIRObservation \
             -v
 
-          # Test: FHIR medication
           python -m pytest tests/system/test_fhir_compliance.py::TestFHIRMedication \
             -v
 
@@ -183,11 +181,9 @@ jobs:
         run: |
           echo "🔗 EHR Integration Testing"
 
-          # Test: Export to EHR (FHIR)
           python -m pytest tests/system/test_ehr_integration.py::TestEHRExport \
             -v
 
-          # Test: Import from EHR (OAuth token validation)
           python -m pytest tests/system/test_ehr_integration.py::TestEHRImport \
             -v
 
@@ -203,7 +199,8 @@ jobs:
   # =========================================================================
   compliance-verification:
     name: Compliance Verification (IEC 62304, CFR Part 11, HIPAA)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -220,12 +217,10 @@ jobs:
         run: |
           echo "📐 IEC 62304: Design Traceability Matrix"
 
-          # Check that each requirement has corresponding design + test
           python3 <<'EOF'
           import os
           import json
 
-          # Requirements mapping
           requirements = {
             "REQ-AUTH": {
               "design": ["src/auth.py"],
@@ -254,7 +249,6 @@ jobs:
         run: |
           echo "📋 CFR Part 11: Audit Trail Compliance"
 
-          # Check for audit trail features
           python3 <<'EOF'
           import os
 
@@ -281,17 +275,14 @@ jobs:
         run: |
           echo "🔐 HIPAA: Security Rule Compliance"
 
-          # Check encryption configuration
           grep -r "AES-256-GCM" infrastructure/kubernetes infrastructure/terraform \
             && echo "✅ Encryption algorithm verified" \
             || echo "❌ Encryption algorithm not configured"
 
-          # Check access control
           grep -r "REQUIRE_MFA" infrastructure/kubernetes \
             && echo "✅ MFA requirement verified" \
             || echo "❌ MFA not required"
 
-          # Check encryption in transit
           grep -r "TLS\|tls\|https" src/ \
             && echo "✅ TLS configured" \
             || echo "❌ TLS not configured"
@@ -301,7 +292,8 @@ jobs:
   # =========================================================================
   security-scan:
     name: Container Security Scan
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 20
     permissions:
       contents: read
       security-events: write
@@ -332,7 +324,8 @@ jobs:
   # =========================================================================
   verification-summary:
     name: V&V Summary (Gates 3-4 Complete)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 5
     needs: [integration-tests, system-tests, compliance-verification]
     if: always()
 

--- a/.github/workflows/03-release-and-deploy.yml
+++ b/.github/workflows/03-release-and-deploy.yml
@@ -30,7 +30,8 @@ jobs:
   # =========================================================================
   build:
     name: Build Release Artifact
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -86,7 +87,8 @@ jobs:
   # =========================================================================
   sbom:
     name: Generate SBOM (CycloneDX)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 20
     needs: build
     permissions:
       contents: read
@@ -143,7 +145,8 @@ jobs:
   # =========================================================================
   provenance:
     name: Generate SLSA v1.0 Provenance
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 20
     needs: build
     permissions:
       contents: read
@@ -192,7 +195,8 @@ jobs:
   # =========================================================================
   vulnerability-scan:
     name: Vulnerability Scanning
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 20
     needs: build
     permissions:
       contents: read
@@ -219,7 +223,8 @@ jobs:
   # =========================================================================
   deploy-staging:
     name: Deploy to Staging
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 20
     needs: [build, sbom, provenance, vulnerability-scan]
     if: github.ref == 'refs/heads/main'
     permissions:
@@ -284,7 +289,8 @@ jobs:
   # =========================================================================
   approval-production:
     name: Await Manual Approval for Production
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 60
     needs: [deploy-staging]
     environment:
       name: production
@@ -306,7 +312,8 @@ jobs:
   # =========================================================================
   deploy-production:
     name: Deploy to Production
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 30
     needs: [build, approval-production]
     if: github.ref == 'refs/heads/main'
     permissions:
@@ -382,7 +389,8 @@ jobs:
   # =========================================================================
   release-summary:
     name: Release Summary (Gate 5 Complete)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 5
     needs: [build, sbom, provenance, vulnerability-scan, deploy-staging, deploy-production]
     if: always()
 

--- a/.github/workflows/test-mac-runner.yml
+++ b/.github/workflows/test-mac-runner.yml
@@ -1,14 +1,86 @@
-name: Test Mac Runner
+name: Test Mac Runners
 
 on:
   workflow_dispatch:
+  schedule:
+    # Run daily at 08:00 UTC to verify runners are healthy
+    - cron: '0 8 * * *'
 
 jobs:
-  test:
+  # -----------------------------------------------------------------------
+  # Mac Studio — always-on primary runner
+  # -----------------------------------------------------------------------
+  test-mac-studio:
+    name: Smoke Test — Mac Studio
     runs-on: [self-hosted, mac-studio]
-    timeout-minutes: 5
+    timeout-minutes: 10
+
     steps:
-      - run: echo "Mac runner works!"
-      - run: gh --version
-      - run: |
+      - name: Runner info
+        run: |
+          echo "Hostname:  $(hostname)"
+          echo "OS:        $(sw_vers -productName) $(sw_vers -productVersion)"
+          echo "Arch:      $(uname -m)"
+          echo "CPU cores: $(sysctl -n hw.logicalcpu)"
+          echo "RAM:       $(( $(sysctl -n hw.memsize) / 1024 / 1024 / 1024 )) GB"
+
+      - name: Verify required tools
+        run: |
+          echo "--- Core tools ---"
+          git --version
+          gh --version
+          python3 --version
+          node --version || echo "node not found"
+          docker --version
+          docker compose version 2>/dev/null || docker-compose --version 2>/dev/null || echo "docker compose not found"
+
+      - name: Verify Docker is running
+        run: |
+          docker info > /dev/null
+          echo "Docker daemon: OK"
+
+      - name: GitHub CLI auth check
+        run: |
           gh repo list ruralpeds --json name --limit 5 --jq '.[].name'
+
+      - name: Self-test complete
+        run: echo "Mac Studio runner OK"
+
+  # -----------------------------------------------------------------------
+  # MacBook Pro — secondary runner (online when lid is open)
+  # -----------------------------------------------------------------------
+  test-macbook-pro:
+    name: Smoke Test — MacBook Pro
+    runs-on: [self-hosted, macbook-pro]
+    timeout-minutes: 10
+
+    steps:
+      - name: Runner info
+        run: |
+          echo "Hostname:  $(hostname)"
+          echo "OS:        $(sw_vers -productName) $(sw_vers -productVersion)"
+          echo "Arch:      $(uname -m)"
+          echo "CPU cores: $(sysctl -n hw.logicalcpu)"
+          echo "RAM:       $(( $(sysctl -n hw.memsize) / 1024 / 1024 / 1024 )) GB"
+
+      - name: Verify required tools
+        run: |
+          echo "--- Core tools ---"
+          git --version
+          gh --version
+          python3 --version
+          node --version || echo "node not found"
+          docker --version
+          docker compose version 2>/dev/null || docker-compose --version 2>/dev/null || echo "docker compose not found"
+
+      - name: Verify Docker is running
+        run: |
+          docker info > /dev/null
+          echo "Docker daemon: OK"
+
+      - name: GitHub CLI auth check
+        run: |
+          gh repo list ruralpeds --json name --limit 5 --jq '.[].name'
+
+      - name: Self-test complete
+        run: echo "MacBook Pro runner OK"


### PR DESCRIPTION
- Replace all ubuntu-latest runners with [self-hosted, macos] so jobs
  run on Mac Studio or MacBook Pro when either is online
- Add per-job timeout-minutes to avoid indefinite queuing
- Remove Docker service containers (Linux-only feature) from
  01-build-and-test and 02-integration-system-tests; start PostgreSQL
  and Redis via docker run in setup steps with docker rm -f cleanup on
  always() so containers are never orphaned
- Replace psql client install (apt-get) with docker exec psql calls
- Expand test-mac-runner.yml into a dual-job smoke test that covers
  both mac-studio and macbook-pro labels, runs daily at 08:00 UTC,
  and validates git, gh, python, docker, and GitHub CLI auth

Runner label conventions:
  [self-hosted, macos]       – any available Mac runner (both machines)
  [self-hosted, mac-studio]  – Mac Studio specifically
  [self-hosted, macbook-pro] – MacBook Pro specifically

https://claude.ai/code/session_012afAvvFyUPjKwx4nJkhjUf