### PR TITLE
feat(governance): org custom repository properties system (#19)

### DIFF
--- a/.github/workflows/custom-properties-audit.yml
+++ b/.github/workflows/custom-properties-audit.yml
@@ -1,0 +1,180 @@
+name: Custom Properties Audit
+
+# Weekly audit: list repos missing required custom properties and
+# open/update a tracking issue. Implements phase-01 task-03.
+#
+# Standards: NIST SSDF PO.1, HITRUST 01.a
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"  # Mondays 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: Audit Custom Properties
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml requests
+
+      - name: Run audit
+        id: audit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG: ${{ github.repository_owner }}
+        run: |
+          python3 - << 'PYEOF'
+          import json, os, sys, datetime
+          import urllib.request, urllib.parse
+
+          token = os.environ["GH_TOKEN"]
+          org   = os.environ["ORG"]
+          headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          import yaml
+          schema = yaml.safe_load(open("policies/custom-properties/schema.yaml"))
+          required_props = {p["name"] for p in schema["properties"] if p.get("required")}
+
+          def gh_get(path, params=None):
+            url = f"https://api.github.com{path}"
+            if params:
+              url += "?" + urllib.parse.urlencode(params)
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req) as r:
+              data = json.loads(r.read())
+            link = r.headers.get("Link", "")
+            return data, link
+
+          # Paginate repos
+          repos, page = [], 1
+          while True:
+            data, link = gh_get(f"/orgs/{org}/repos", {"per_page": 100, "page": page, "type": "all"})
+            repos.extend(data)
+            if 'rel="next"' not in link:
+              break
+            page += 1
+
+          print(f"Repos found: {len(repos)}")
+
+          gaps = []
+          for repo in repos:
+            name = repo["name"]
+            if repo.get("archived"):
+              continue
+            try:
+              props_data, _ = gh_get(f"/repos/{org}/{name}/properties/values")
+              set_names = {p["property_name"] for p in props_data}
+            except Exception:
+              set_names = set()
+
+            missing = sorted(required_props - set_names)
+            if missing:
+              gaps.append({"repo": name, "missing": missing})
+
+          gaps.sort(key=lambda x: x["repo"])
+
+          week = datetime.date.today().strftime("%Y-W%V")
+          report_path = f"reports/custom-properties-{week}.md"
+          os.makedirs("reports", exist_ok=True)
+
+          lines = [
+            f"# Custom Properties Audit — {week}",
+            "",
+            f"**Date:** {datetime.date.today().isoformat()}  ",
+            f"**Repos checked:** {len([r for r in repos if not r.get('archived')])}  ",
+            f"**Repos with gaps:** {len(gaps)}",
+            "",
+          ]
+          if gaps:
+            lines += ["| Repository | Missing Properties |", "|---|---|"]
+            for g in gaps:
+              lines.append(f"| `{g['repo']}` | {', '.join(f'`{m}`' for m in g['missing'])} |")
+          else:
+            lines.append("✅ All repositories have all required custom properties set.")
+
+          open(report_path, "w").write("\n".join(lines) + "\n")
+          print("\n".join(lines))
+
+          # Write outputs
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            f.write(f"gap_count={len(gaps)}\n")
+            f.write(f"week={week}\n")
+            f.write(f"report_path={report_path}\n")
+
+          PYEOF
+
+      - name: Upload report
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v3
+        with:
+          name: custom-properties-report-${{ steps.audit.outputs.week }}
+          path: reports/
+
+      - name: Create or update tracking issue
+        if: steps.audit.outputs.gap_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const week = '${{ steps.audit.outputs.week }}';
+            const gapCount = '${{ steps.audit.outputs.gap_count }}';
+            const reportPath = '${{ steps.audit.outputs.report_path }}';
+            const body = fs.readFileSync(reportPath, 'utf8');
+
+            const title = `Custom properties audit — ${week}`;
+
+            // Find existing open issue for this week
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'governance,custom-properties',
+            });
+            const match = existing.data.find(i => i.title === title);
+
+            if (match) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body,
+              });
+              console.log(`Updated issue #${match.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['governance', 'custom-properties'],
+              });
+              console.log(`Created issue #${created.data.number}`);
+            }
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Custom Properties Audit" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Week: **${{ steps.audit.outputs.week }}**" >> $GITHUB_STEP_SUMMARY
+          echo "Repos with gaps: **${{ steps.audit.outputs.gap_count }}**" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ The baseline ruleset `signed-commits-main.json` enforces:
 - PHI scrubbing scan required as a merge gate
 - Code scanning must pass (blocks high+ findings from phi-scan category)
 
+### Org Custom Repository Properties
+
+Every repository carries six metadata properties that drive automated governance decisions — rulesets, audit depth, DHF scaffolding, and more:
+
+| Property | Values | Approval |
+|---|---|---|
+| `data-classification` | `public` / `internal` / `synthetic` / `phi-capable` / `phi-active` | self-serve |
+| `criticality` | `experimental` / `reference` / `clinical-support` / `clinical-decision` / `device` | self-serve |
+| `iec62304-class` | `not-applicable` / `class-a` / `class-b` / `class-c` | clinical-lead |
+| `regulated` | `true` / `false` | clinical-lead |
+| `primary-stack` | `julia` / `rust` / `node` / `python` / `go` / `content` / `polyglot` | self-serve |
+| `baa-required` | `true` / `false` | self-serve |
+
+Set properties interactively:
+```bash
+export GH_TOKEN=$(gh auth token)
+python scripts/set-properties.py ruralpeds/my-repo
+```
+
+See **[`docs/governance/custom-properties.md`](docs/governance/custom-properties.md)** for full documentation including downstream effects, change approval requirements, and the weekly audit workflow (`custom-properties-audit.yml`).
+
 ### Supply-Chain Attestation Trio (P1)
 
 For every release of a clinical repo, four artifacts travel together to form a complete supply-chain evidence package:
@@ -297,9 +318,11 @@ Requires `REPO_SETUP_TOKEN` secret (fine-grained PAT with Contents + PRs + Workf
 
 | Time (UTC Mon) | Workflow | Purpose |
 |---|---|---|
+| 05:00 | sync-rulesets.yml | Apply governance rulesets to all org repos |
 | 06:00 | repo-scanner.yml | Bootstrap missing CI workflows via PRs |
 | 07:00 | check-compliance.yml | Scan all repos, create issue if non-compliant |
 | 08:00 | playwright-audit.yml | Visual audit of org Actions status |
+| 09:00 | custom-properties-audit.yml | Audit repos missing required custom properties |
 
 ## Example Usage
 

--- a/docs/governance/custom-properties.md
+++ b/docs/governance/custom-properties.md
@@ -1,0 +1,170 @@
+# Org Custom Repository Properties
+
+Every repository in `ruralpeds` carries six metadata properties that drive automated governance decisions — rulesets, audit depth, DHF scaffolding, and more. This document explains each property, how to change it, and what happens downstream.
+
+---
+
+## Properties
+
+### `data-classification`
+
+| Value | Meaning |
+|---|---|
+| `public` | Publicly available; no ePHI, no PII |
+| `internal` | Internal use; no ePHI; may contain internal docs/designs |
+| `synthetic` | Synthetic test data (Synthea fixtures, mock patients); never real ePHI |
+| `phi-capable` | Can process ePHI in principle; not actively doing so today |
+| `phi-active` | Actively processes or stores real ePHI in production |
+
+**Downstream effects:**
+- `phi-active` → activates the PHI-scan workflow and HIPAA BAA check; `baa-required` should also be `true`.
+
+**Who can change:** Self-serve.
+
+---
+
+### `criticality`
+
+| Value | Meaning |
+|---|---|
+| `experimental` | Research, prototype, PoC; not used clinically |
+| `reference` | Reference docs, educational content |
+| `clinical-support` | Supports clinical workflows but not on the critical path |
+| `clinical-decision` | Directly influences clinical decisions (alarms, calculators) |
+| `device` | Software as a Medical Device (SaMD) under FDA/IEC 62304 |
+
+**Downstream effects:**
+- `clinical-decision` → requires HA configuration (phase 8).
+- `device` → requires FDA cybersecurity plan, SBOM, and SLSA attestation.
+
+**Who can change:** Self-serve.
+
+---
+
+### `iec62304-class`
+
+| Value | Meaning |
+|---|---|
+| `not-applicable` | Not a medical device; IEC 62304 does not apply |
+| `class-a` | Class A: No injury possible (display-only, informational) |
+| `class-b` | Class B: Non-serious injury possible |
+| `class-c` | Class C: Death or serious injury possible |
+
+**Downstream effects:**
+- `class-b` or `class-c` → activates `reusable-iec62304-traceability.yml` on every PR; the DHF scaffold must be present.
+
+**Who can change:** Requires **clinical-lead** approval — changing class alters regulatory scope and triggers a full DHF review.
+
+---
+
+### `regulated`
+
+| Value | Meaning |
+|---|---|
+| `true` | Subject to regulatory oversight (FDA, EMA, Health Canada, etc.) |
+| `false` | Not regulated |
+
+**Downstream effects:**
+- `true` → activates SLSA provenance, SBOM attestation, and the release gate workflow.
+
+**Who can change:** Requires **clinical-lead** approval.
+
+---
+
+### `primary-stack`
+
+| Value | Meaning |
+|---|---|
+| `julia` | Julia (scientific computing, PedNeoSim) |
+| `rust` | Rust (systems, performance-critical) |
+| `node` | Node.js / TypeScript |
+| `python` | Python |
+| `go` | Go |
+| `content` | Docs, education, markdown-only |
+| `polyglot` | Multiple languages / monorepo |
+
+**Downstream effects:**
+- Selects which reusable CI workflow (e.g., `reusable-ci-julia.yml`) is used by consuming repos.
+
+**Who can change:** Self-serve.
+
+---
+
+### `baa-required`
+
+| Value | Meaning |
+|---|---|
+| `true` | A HIPAA BAA must be on file before production ePHI flows |
+| `false` | BAA not required |
+
+**Downstream effects:**
+- `true` → compliance automation checks for a BAA record in the org wiki.
+
+**Who can change:** Self-serve (but must be consistent with `data-classification`).
+
+---
+
+## How to Set Properties
+
+### Interactive wizard (recommended)
+
+```bash
+export GH_TOKEN=$(gh auth token)
+python scripts/set-properties.py ruralpeds/my-repo
+```
+
+The wizard will show each property's current value, allowed options, and prompt for a new value. Press Enter to keep the current value.
+
+### Non-interactive (for automation or bulk updates)
+
+```bash
+python scripts/set-properties.py \
+  --set iec62304-class=class-b \
+  --set regulated=true \
+  ruralpeds/my-repo
+```
+
+Use `--dry-run` to preview changes without applying them:
+
+```bash
+python scripts/set-properties.py --dry-run ruralpeds/my-repo
+```
+
+### Verify current values
+
+```bash
+gh api repos/ruralpeds/my-repo/properties/values | jq
+```
+
+### GitHub UI
+
+Organization Settings → Custom Properties → select the repo → edit values.
+
+---
+
+## One-time Setup (Org Owner only)
+
+The six property **definitions** must be created once by an org owner via the GitHub UI or API. The JSON schema at `policies/custom-properties.json` is the canonical definition — use it to recreate the properties if they are ever deleted.
+
+---
+
+## Weekly Audit
+
+The `custom-properties-audit.yml` workflow runs every Monday at 09:00 UTC and opens (or updates) a tracking issue listing any repos missing required properties.
+
+Run manually:
+
+```bash
+gh workflow run custom-properties-audit.yml
+```
+
+---
+
+## Downstream Phase Dependencies
+
+| Phase | Property dependency |
+|---|---|
+| Phase 3 — Rulesets | `iec62304-class`, `data-classification` |
+| Phase 4 — Audit depth | `criticality` |
+| Phase 6 — DHF scaffold | `iec62304-class != not-applicable` |
+| Phase 8 — HA patterns | `criticality >= clinical-decision` |

--- a/policies/custom-properties/schema.yaml
+++ b/policies/custom-properties/schema.yaml
@@ -1,0 +1,123 @@
+# Org-level custom repository property schema
+# Single source of truth — consumed by:
+#   - .github/workflows/custom-properties-audit.yml (compliance checking)
+#   - scripts/set-properties.py (interactive wizard)
+#   - Phase 3 rulesets (target repos by iec62304-class, data-classification)
+#
+# GitHub API ref: PATCH /repos/{owner}/{repo}/properties/values
+# Org definitions: Organization Settings → Custom Properties
+
+version: "1.0"
+last_updated: "2026-04-26"
+
+properties:
+
+  - name: data-classification
+    description: >
+      Data classification level. Controls ePHI handling requirements,
+      BAA scope, and which security rulesets apply.
+    value_type: single_select
+    required: true
+    default: internal
+    allowed_values:
+      - name: public
+        description: Publicly available; no ePHI, no PII
+      - name: internal
+        description: Internal use; no ePHI; may contain internal docs/designs
+      - name: synthetic
+        description: Synthetic test data (Synthea, mock patients); never real ePHI
+      - name: phi-capable
+        description: Can process ePHI in principle; not actively doing so today
+      - name: phi-active
+        description: Actively processes or stores real ePHI in production
+    change_approval: self-serve
+    downstream_effects:
+      phi-active: Triggers HIPAA BAA check; activates PHI-scan workflow
+
+  - name: criticality
+    description: >
+      Clinical and business criticality. Drives audit depth (phase 4),
+      HA requirements (phase 8), and incident response SLA.
+    value_type: single_select
+    required: true
+    default: experimental
+    allowed_values:
+      - name: experimental
+        description: Research, prototype, proof-of-concept; not used clinically
+      - name: reference
+        description: Reference docs, educational content; no clinical decision support
+      - name: clinical-support
+        description: Supports clinical workflows but not on the critical path
+      - name: clinical-decision
+        description: Directly influences clinical decisions (alarms, calculators)
+      - name: device
+        description: Software as a Medical Device (SaMD) under FDA/IEC 62304
+    change_approval: self-serve
+    downstream_effects:
+      clinical-decision: Requires HA configuration (phase 8)
+      device: Requires FDA cybersecurity plan and SBOM
+
+  - name: iec62304-class
+    description: >
+      IEC 62304 software safety classification. Gates DHF scaffold
+      generation (phase 6) and traceability workflow activation.
+    value_type: single_select
+    required: true
+    default: not-applicable
+    allowed_values:
+      - name: not-applicable
+        description: Not a medical device; IEC 62304 not applicable
+      - name: class-a
+        description: "Class A: No injury possible (display-only, informational)"
+      - name: class-b
+        description: "Class B: Non-serious injury possible (alarms, calculators)"
+      - name: class-c
+        description: "Class C: Death or serious injury possible (infusion, ventilation)"
+    change_approval: clinical-lead  # escalated — changing class affects regulatory scope
+    downstream_effects:
+      class-b: Activates reusable-iec62304-traceability.yml
+      class-c: Activates reusable-iec62304-traceability.yml + additional risk controls
+
+  - name: regulated
+    description: >
+      Whether this software is subject to regulatory oversight
+      (FDA, EMA, Health Canada, etc.).
+    value_type: true_false
+    required: true
+    default: "false"
+    change_approval: clinical-lead
+    downstream_effects:
+      "true": Activates SLSA provenance, SBOM attestation, and release gate
+
+  - name: primary-stack
+    description: Primary technology stack / programming language.
+    value_type: single_select
+    required: true
+    default: null
+    allowed_values:
+      - name: julia
+        description: Julia (scientific computing, simulations, PedNeoSim)
+      - name: rust
+        description: Rust (systems, performance-critical, medical devices)
+      - name: node
+        description: Node.js / TypeScript (web, API, React)
+      - name: python
+        description: Python (data science, scripting, analysis)
+      - name: go
+        description: Go (services, CLI tools, microservices)
+      - name: content
+        description: Content (docs, education, markdown-based repos)
+      - name: polyglot
+        description: Multiple languages / monorepo
+    change_approval: self-serve
+
+  - name: baa-required
+    description: >
+      Whether this repo/service requires a HIPAA Business Associate Agreement.
+      Must be true whenever data-classification is phi-active.
+    value_type: true_false
+    required: true
+    default: "false"
+    change_approval: self-serve
+    downstream_effects:
+      "true": BAA must be on file before any production data flows through this service

--- a/scripts/set-properties.py
+++ b/scripts/set-properties.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Interactive wizard to set GitHub org custom repository properties.
+
+Usage:
+    python scripts/set-properties.py <owner>/<repo>
+    python scripts/set-properties.py --dry-run ruralpeds/.github
+    python scripts/set-properties.py --set iec62304-class=class-b ruralpeds/my-repo
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+SCHEMA_PATH = Path(__file__).parent.parent / "policies" / "custom-properties" / "schema.yaml"
+API_BASE = "https://api.github.com"
+
+
+def gh_token() -> str:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        sys.exit("Error: set GH_TOKEN or GITHUB_TOKEN environment variable.")
+    return token
+
+
+def api_request(method: str, path: str, body=None, token: str = "") -> dict:
+    url = f"{API_BASE}{path}"
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as r:
+            return json.loads(r.read()) if r.length else {}
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode()
+        sys.exit(f"GitHub API error {e.code}: {body_text}")
+
+
+def load_schema() -> list[dict]:
+    try:
+        import yaml  # type: ignore
+        return yaml.safe_load(SCHEMA_PATH.read_text())["properties"]
+    except ImportError:
+        import json as _j
+        # Fallback: load the JSON variant
+        json_path = SCHEMA_PATH.parent.parent / "custom-properties.json"
+        return _j.loads(json_path.read_text())["properties"]
+
+
+def get_current_values(owner: str, repo: str, token: str) -> dict[str, str]:
+    data = api_request("GET", f"/repos/{owner}/{repo}/properties/values", token=token)
+    return {p["property_name"]: p["value"] for p in data} if isinstance(data, list) else {}
+
+
+def prompt_value(prop: dict, current: str | None) -> str | None:
+    name = prop["name"]
+    allowed = [v["name"] for v in prop.get("allowed_values", [])]
+    value_type = prop.get("value_type", "string")
+
+    print(f"\n  {'─'*60}")
+    print(f"  Property : {name}")
+    print(f"  Type     : {value_type}")
+    print(f"  Description: {prop.get('description', '').strip()}")
+    if current is not None:
+        print(f"  Current  : {current}")
+    if allowed:
+        print(f"  Options  : {', '.join(allowed)}")
+    default = prop.get("default")
+    prompt_suffix = f" [{current or default}]" if (current or default) else ""
+
+    while True:
+        raw = input(f"  Value{prompt_suffix}: ").strip()
+        if not raw:
+            return current or (str(default) if default is not None else None)
+        if value_type == "true_false" and raw.lower() not in ("true", "false"):
+            print("  → Enter 'true' or 'false'")
+            continue
+        if allowed and raw not in allowed:
+            print(f"  → Must be one of: {', '.join(allowed)}")
+            continue
+        return raw
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo", help="owner/repo to update")
+    parser.add_argument("--dry-run", action="store_true", help="Print changes without applying")
+    parser.add_argument(
+        "--set",
+        action="append",
+        metavar="KEY=VALUE",
+        dest="overrides",
+        help="Set a specific property non-interactively (repeatable)",
+    )
+    args = parser.parse_args()
+
+    if "/" not in args.repo:
+        sys.exit("Error: repo must be in owner/repo format")
+    owner, repo = args.repo.split("/", 1)
+
+    token = gh_token()
+    schema = load_schema()
+    current = get_current_values(owner, repo, token)
+
+    print(f"\nSetting custom properties for {owner}/{repo}")
+    print(f"{'─'*62}")
+
+    # Build override map from --set flags
+    overrides: dict[str, str] = {}
+    for kv in (args.overrides or []):
+        if "=" not in kv:
+            sys.exit(f"--set requires KEY=VALUE format, got: {kv}")
+        k, v = kv.split("=", 1)
+        overrides[k] = v
+
+    updates: list[dict] = []
+
+    if overrides:
+        # Non-interactive mode
+        for prop in schema:
+            name = prop["name"]
+            if name in overrides:
+                updates.append({"property_name": name, "value": overrides[name]})
+    else:
+        # Interactive mode
+        for prop in schema:
+            name = prop["name"]
+            value = prompt_value(prop, current.get(name))
+            if value is not None:
+                updates.append({"property_name": name, "value": value})
+
+    if not updates:
+        print("\nNo changes to apply.")
+        return
+
+    print("\n  Changes to apply:")
+    for u in updates:
+        old = current.get(u["property_name"], "(not set)")
+        print(f"    {u['property_name']}: {old!r} → {u['value']!r}")
+
+    if args.dry_run:
+        print("\n[dry-run] No changes written.")
+        return
+
+    confirm = input("\nApply? [y/N]: ").strip().lower()
+    if confirm != "y":
+        print("Aborted.")
+        return
+
+    api_request(
+        "PATCH",
+        f"/repos/{owner}/{repo}/properties/values",
+        body={"properties": updates},
+        token=token,
+    )
+    print(f"\n✅ Properties updated on {owner}/{repo}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #19.

Implements end-to-end tooling for the six org-level custom repository properties that drive automated governance decisions across all `ruralpeds` repos.

- **`policies/custom-properties/schema.yaml`** — single source of truth for all six properties; consumed by the audit workflow and the interactive wizard
- **`scripts/set-properties.py`** — interactive wizard (`--dry-run`, `--set KEY=VALUE`) that calls `PATCH /repos/{owner}/{repo}/properties/values`
- **`.github/workflows/custom-properties-audit.yml`** — weekly Monday 09:00 UTC audit; opens/updates a tracking issue for any repos missing required properties
- **`docs/governance/custom-properties.md`** — full governance documentation (allowed values, downstream effects, approval requirements, phase dependency table)
- **`README.md`** — added Org Custom Repository Properties subsection and updated weekly schedule table

## Properties covered

| Property | Approval |
|---|---|
| `data-classification` | self-serve |
| `criticality` | self-serve |
| `iec62304-class` | clinical-lead |
| `regulated` | clinical-lead |
| `primary-stack` | self-serve |
| `baa-required` | self-serve |

## Test plan

- [ ] Run `python scripts/set-properties.py --dry-run ruralpeds/.github` — should print current values and show `[dry-run] No changes written.`
- [ ] Run `python scripts/set-properties.py --set primary-stack=content ruralpeds/.github` — should apply and confirm
- [ ] Trigger `custom-properties-audit.yml` via `workflow_dispatch` — should produce a report artifact and open a tracking issue if any repos are missing properties
- [ ] Verify `policies/custom-properties/schema.yaml` is read correctly by the audit workflow (check `required_props` set in the Python step)

https://claude.ai/code/session_012afAvvFyUPjKwx4nJkhjUf

---
_Generated by [Claude Code](https://claude.ai/code/session_012afAvvFyUPjKwx4nJkhjUf)_