### PR TITLE
feat(compliance): IEC 62304 traceability workflow and DHF scaffold (#24)

### DIFF
--- a/.github/workflows/reusable-iec62304-traceability.yml
+++ b/.github/workflows/reusable-iec62304-traceability.yml
@@ -1,65 +1,70 @@
-name: "IEC 62304 Requirement Traceability Check"
+name: "Reusable IEC 62304 Traceability Check"
 
-# Validate software requirement traceability: every requirement tested, every test tied to requirement.
-#
-# This workflow enforces IEC 62304 §7 (design verification):
-#   - Every SW-### requirement in dhf/requirements/software-requirements.yaml has ≥1 test case
-#   - Every test case in code maps to a SW-### requirement
-#   - Every risk control (RC-###) is verified by tests
-#   - Code coverage meets Class B/C minimums (Class B: 85%, Class C: 95%)
-#
-# Outputs:
-#   - Pass/fail status
-#   - HTML traceability matrix (artifact)
-#   - SARIF report (for GitHub security tab)
+# Validates IEC 62304 software requirement traceability and ISO 14971 hazard
+# analysis completeness for any repo with iec62304-class set to class-a/b/c.
 #
 # Regulatory drivers:
-#   - IEC 62304 §7 — Software Integration, Verification & System Validation
-#   - ISO 14971 — Risk Controls & Residual Risk Validation
-#   - 21 CFR §820.75 — Process Validation
+#   - IEC 62304:2006+A1:2015 §5.2, §5.5, §5.6, §5.7
+#   - ISO 14971:2019 §7.1, §7.4
+#   - FDA Guidance: Content of Premarket Submissions for Device Software Functions (June 2023)
+#
+# Callers: uses: ruralpeds/.github/.github/workflows/reusable-iec62304-traceability.yml@main
+#
+# Required DHF structure in calling repo:
+#   dhf/requirements/software-requirements.yaml
+#   dhf/risk/hazard-analysis.yaml
+#   dhf/verification/unit-test-map.yaml
+#   dhf/classification.md
 
 on:
   workflow_call:
     inputs:
-      class:
-        description: "Software safety class (a, b, c)"
-        required: true
+      dhf-path:
+        description: "Path to the DHF directory (default: dhf)"
         type: string
-      coverage-report-path:
-        description: "Path to coverage report (cobertura.xml or lcov.info)"
-        required: false
+        default: "dhf"
+      version:
+        description: "Version label for the traceability matrix artifact"
         type: string
-        default: "coverage/coverage.xml"
-      mutation-report-path:
-        description: "Path to mutation test report (json)"
-        required: false
-        type: string
-        default: "coverage/mutation.json"
+        default: "HEAD"
+      fail-on-gap:
+        description: >
+          Fail the workflow if any traceability gap is detected (missing test,
+          orphan risk control, etc.). Set to false to report gaps without
+          blocking the PR.
+        type: boolean
+        default: true
+      skip:
+        description: >
+          Set to true to skip all checks (for repos undergoing DHF initial
+          population). Reports a warning but exits 0.
+        type: boolean
+        default: false
+    outputs:
+      gap-count:
+        description: "Number of traceability gaps found (0 = clean)"
+        value: ${{ jobs.traceability.outputs.gap-count }}
+      matrix-artifact:
+        description: "Name of the uploaded traceability matrix artifact"
+        value: ${{ jobs.traceability.outputs.matrix-artifact }}
 
 permissions:
   contents: read
-  checks: write
   pull-requests: write
 
 jobs:
-  validate-traceability:
-    name: Validate IEC 62304 Traceability
+  traceability:
+    name: IEC 62304 Traceability
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      CLASS: ${{ inputs.class }}
-      MIN_COVERAGE_A: "70"
-      MIN_COVERAGE_B: "85"
-      MIN_COVERAGE_C: "95"
-      MIN_MUTATION_A: "0"
-      MIN_MUTATION_B: "70"
-      MIN_MUTATION_C: "85"
-
+    outputs:
+      gap-count: ${{ steps.gaps.outputs.gap_count }}
+      matrix-artifact: traceability-matrix-${{ inputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5
@@ -67,339 +72,118 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
+        run: pip install pyyaml jsonschema
+
+      - name: Skip notice
+        if: inputs.skip
         run: |
-          pip install pyyaml jinja2 xml.etree.ElementTree
+          echo "::warning::IEC 62304 traceability checks are SKIPPED (skip=true)."
+          echo "::warning::Set skip=false before the first release of a class-b or class-c software item."
 
-      - name: Parse requirements specification
-        id: parse-reqs
+      - name: Check DHF structure
+        if: "!inputs.skip"
         run: |
-          echo "=== Parsing Requirements Specification ==="
-
-          python3 <<'PYTHON_EOF'
-          import yaml
-          import json
-
-          # Load requirements YAML
-          try:
-              with open('dhf/requirements/software-requirements.yaml', 'r') as f:
-                  spec = yaml.safe_load(f)
-          except FileNotFoundError:
-              print("❌ dhf/requirements/software-requirements.yaml not found")
-              exit(1)
-
-          requirements = spec.get('requirements', [])
-          req_ids = [r['id'] for r in requirements]
-
-          print(f"✅ Found {len(requirements)} requirements")
-          for req in requirements[:5]:
-              print(f"  - {req['id']}: {req['title']}")
-
-          # Write to file for next step
-          with open('/tmp/requirements.json', 'w') as f:
-              json.dump({'requirements': req_ids}, f)
-
-          print(f"\nTotal: {len(req_ids)} SW-### requirements")
-          PYTHON_EOF
-
-      - name: Scan code for requirement annotations
-        id: scan-code
-        run: |
-          echo "=== Scanning Code for @requirement and @mitigates Annotations ==="
-
-          python3 <<'PYTHON_EOF'
-          import os
-          import re
-          import json
-
-          # Find all source files (src/, tests/)
-          src_files = []
-          for root, dirs, files in os.walk('.'):
-              # Skip dhf/, .git, etc.
-              dirs[:] = [d for d in dirs if d not in ['.git', 'dhf', '.github', 'node_modules', '.venv']]
-              for file in files:
-                  if file.endswith(('.rs', '.py', '.jl', '.go', '.ts', '.js')):
-                      src_files.append(os.path.join(root, file))
-
-          annotations = {
-              'requirement': set(),
-              'mitigates': set(),
-              'test_case': set()
-          }
-
-          # Scan for annotations
-          for src_file in src_files:
-              try:
-                  with open(src_file, 'r', encoding='utf-8', errors='ignore') as f:
-                      content = f.read()
-
-                      # Find @requirement("SW-###") patterns
-                      for match in re.finditer(r'@requirement\("(SW-\d+)"\)', content):
-                          annotations['requirement'].add(match.group(1))
-
-                      # Find @mitigates("RC-###") patterns
-                      for match in re.finditer(r'@mitigates\("(RC-\d+)"\)', content):
-                          annotations['mitigates'].add(match.group(1))
-
-                      # Find @test-case("TC-###") patterns
-                      for match in re.finditer(r'@test-case\("(TC-\d+)"\)', content):
-                          annotations['test_case'].add(match.group(1))
-              except Exception as e:
-                  pass  # Skip binary files
-
-          print(f"✅ Scanned {len(src_files)} source files")
-          print(f"  - {len(annotations['requirement'])} @requirement annotations found")
-          print(f"  - {len(annotations['mitigates'])} @mitigates annotations found")
-          print(f"  - {len(annotations['test_case'])} @test-case annotations found")
-
-          # Write to file
-          with open('/tmp/annotations.json', 'w') as f:
-              json.dump({k: list(v) for k, v in annotations.items()}, f)
-
-          PYTHON_EOF
-
-      - name: Validate test case coverage
-        id: validate-coverage
-        run: |
-          echo "=== Validating Test Case Coverage ==="
-
-          python3 <<'PYTHON_EOF'
-          import yaml
-          import json
-          import sys
-
-          # Load requirements
-          with open('dhf/requirements/software-requirements.yaml', 'r') as f:
-              spec = yaml.safe_load(f)
-          requirements = {r['id']: r for r in spec.get('requirements', [])}
-
-          # Load test case map
-          try:
-              with open('dhf/verification/unit-test-map.yaml', 'r') as f:
-                  test_spec = yaml.safe_load(f)
-              test_cases = {t['id']: t for t in test_spec.get('test_cases', [])}
-          except FileNotFoundError:
-              print("⚠️  dhf/verification/unit-test-map.yaml not found (optional for Phase 6 beta)")
-              test_cases = {}
-
-          # Check: every requirement has ≥1 test
-          uncovered_reqs = []
-          for req_id in requirements.keys():
-              tests = [t for t in test_cases.values() if t.get('requirement_tested') == req_id]
-              if not tests and not 'non-functional' in requirements[req_id].get('category', ''):
-                  uncovered_reqs.append(req_id)
-              if tests:
-                  print(f"  ✅ {req_id}: {len(tests)} test(s)")
-
-          if uncovered_reqs:
-              print(f"\n❌ COVERAGE FAIL: {len(uncovered_reqs)} requirements have no tests:")
-              for req_id in uncovered_reqs:
-                  print(f"  - {req_id}: {requirements[req_id]['title']}")
-              sys.exit(1)
-          else:
-              print(f"\n✅ COVERAGE PASS: All {len(requirements)} requirements have test coverage")
-
-          # Write results
-          with open('/tmp/coverage_check.json', 'w') as f:
-              json.dump({'status': 'pass', 'uncovered': uncovered_reqs}, f)
-
-          PYTHON_EOF
-
-      - name: Check code coverage metrics
-        id: check-coverage
-        run: |
-          echo "=== Checking Code Coverage Metrics ==="
-
-          # Determine minimum coverage threshold based on class
-          if [ "$CLASS" = "a" ]; then
-            MIN_COV=70
-            MIN_MUT=0
-          elif [ "$CLASS" = "b" ]; then
-            MIN_COV=85
-            MIN_MUT=70
-          else
-            # class c
-            MIN_COV=95
-            MIN_MUT=85
+          DHF="${{ inputs.dhf-path }}"
+          MISSING=""
+          for d in "$DHF/requirements" "$DHF/risk" "$DHF/verification"; do
+            if [ ! -d "$d" ]; then
+              MISSING="$MISSING $d"
+            fi
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::Missing DHF directories:$MISSING"
+            echo "Run: cp -r templates/dhf/ $DHF/ to initialize"
+            exit 1
           fi
 
-          echo "Coverage requirements for Class $CLASS:"
-          echo "  Minimum line coverage: $MIN_COV%"
-          echo "  Minimum mutation kill rate: $MIN_MUT%"
-
-          # Parse coverage report (if present)
-          if [ -f "${{ inputs.coverage-report-path }}" ]; then
-              echo ""
-              echo "Coverage report found: ${{ inputs.coverage-report-path }}"
-
-              python3 <<'PYTHON_EOF'
-          import xml.etree.ElementTree as ET
-          import json
-          import sys
-
-          try:
-              tree = ET.parse('${{ inputs.coverage-report-path }}')
-              root = tree.getroot()
-
-              # Parse Cobertura XML format
-              if root.tag == 'coverage':
-                  line_rate = float(root.get('line-rate', 0)) * 100
-                  branch_rate = float(root.get('branch-rate', 0)) * 100
-
-                  print(f"📊 Coverage Report:")
-                  print(f"  Line coverage: {line_rate:.1f}%")
-                  print(f"  Branch coverage: {branch_rate:.1f}%")
-
-                  min_cov = int('$MIN_COV')
-                  if line_rate >= min_cov:
-                      print(f"  ✅ Line coverage PASS ({line_rate:.1f}% >= {min_cov}%)")
-                  else:
-                      print(f"  ❌ Line coverage FAIL ({line_rate:.1f}% < {min_cov}%)")
-                      sys.exit(1)
-          except Exception as e:
-              print(f"⚠️  Could not parse coverage report: {e}")
-          PYTHON_EOF
-          else
-              echo "⚠️  Coverage report not found (optional)"
-          fi
-
-      - name: Generate traceability matrix
+      - name: Build traceability matrix
+        if: "!inputs.skip"
         id: matrix
         run: |
-          echo "=== Generating Traceability Matrix ==="
+          python scripts/traceability/build_matrix.py \
+            --dhf "${{ inputs.dhf-path }}" \
+            --version "${{ inputs.version }}" \
+            --out "/tmp/traceability-out/"
 
-          python3 <<'PYTHON_EOF'
-          import yaml
-          import json
-          from datetime import datetime
-
-          # Load requirements
-          with open('dhf/requirements/software-requirements.yaml', 'r') as f:
-              spec = yaml.safe_load(f)
-          requirements = spec.get('requirements', [])
-
-          # Load test cases
-          try:
-              with open('dhf/verification/unit-test-map.yaml', 'r') as f:
-                  test_spec = yaml.safe_load(f)
-              test_cases = test_spec.get('test_cases', [])
-          except FileNotFoundError:
-              test_cases = []
-
-          # Build matrix HTML
-          html = f"""<!DOCTYPE html>
-<html>
-<head>
-    <title>IEC 62304 Traceability Matrix</title>
-    <style>
-        body {{ font-family: monospace; background: #f5f5f5; padding: 20px; }}
-        table {{ border-collapse: collapse; width: 100%; background: white; }}
-        th, td {{ border: 1px solid #ccc; padding: 8px; text-align: left; }}
-        th {{ background: #2c3e50; color: white; }}
-        tr:nth-child(even) {{ background: #f9f9f9; }}
-        .pass {{ color: green; font-weight: bold; }}
-        .fail {{ color: red; font-weight: bold; }}
-        .badge {{ display: inline-block; padding: 2px 6px; border-radius: 3px; margin: 2px; font-size: 0.8em; }}
-        .critical {{ background: #e74c3c; color: white; }}
-        .high {{ background: #f39c12; color: white; }}
-        .medium {{ background: #f1c40f; }}
-        .info {{ background: #3498db; color: white; }}
-    </style>
-</head>
-<body>
-    <h1>IEC 62304 Requirement Traceability Matrix</h1>
-    <p>Generated: {datetime.now().isoformat()}</p>
-    <p>Class: {spec.get('metadata', {}).get('class', 'unknown').upper()}</p>
-
-    <h2>Requirements Summary</h2>
-    <table>
-        <tr>
-            <th>Requirement ID</th>
-            <th>Title</th>
-            <th>Category</th>
-            <th>Priority</th>
-            <th>Test Cases</th>
-            <th>Status</th>
-        </tr>
-"""
-
-          for req in requirements:
-              req_id = req.get('id')
-              title = req.get('title', 'Untitled')
-              category = req.get('category', 'unknown')
-              priority = req.get('priority', 'medium')
-
-              # Find test cases for this requirement
-              tests = [t for t in test_cases if t.get('requirement_tested') == req_id]
-              test_links = ', '.join([f"<a href='#{t['id']}'>{t['id']}</a>" for t in tests])
-
-              status = '<span class="pass">✓ Tested</span>' if tests else '<span class="fail">✗ No tests</span>'
-              priority_badge = f'<span class="badge critical">{priority}</span>' if priority == 'critical' else f'<span class="badge">{priority}</span>'
-
-              html += f"""        <tr>
-            <td><strong>{req_id}</strong></td>
-            <td>{title}</td>
-            <td>{category}</td>
-            <td>{priority_badge}</td>
-            <td>{test_links if test_links else '(none)'}</td>
-            <td>{status}</td>
-        </tr>
-"""
-
-          html += """    </table>
-</body>
-</html>
-"""
-
-          with open('/tmp/traceability-matrix.html', 'w') as f:
-              f.write(html)
-
-          print("✅ Traceability matrix generated")
-          PYTHON_EOF
-
-      - name: Create traceability report
+      - name: Check traceability gaps
+        if: "!inputs.skip"
+        id: gaps
         run: |
-          echo "=== Traceability Validation Result ==="
-          echo ""
-          echo "✅ Requirements specification: parsed"
-          echo "✅ Test case map: validated"
-          echo "✅ Code coverage: checked"
-          echo "✅ Traceability matrix: generated"
-          echo ""
-          echo "Status: PASS"
+          set +e
+          python scripts/traceability/check_gaps.py \
+            --dhf "${{ inputs.dhf-path }}" \
+            2>&1 | tee /tmp/gap-report.txt
+          GAP_EXIT=$?
+          set -e
 
-      - name: Upload traceability matrix
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+          GAP_COUNT=$(grep -c "^ERROR:" /tmp/gap-report.txt 2>/dev/null || echo 0)
+          echo "gap_count=$GAP_COUNT" >> "$GITHUB_OUTPUT"
+
+          if [ "$GAP_EXIT" -ne 0 ] && [ "${{ inputs.fail-on-gap }}" = "true" ]; then
+            echo "::error::$GAP_COUNT traceability gap(s) detected. See gap-report above."
+            exit "$GAP_EXIT"
+          elif [ "$GAP_EXIT" -ne 0 ]; then
+            echo "::warning::$GAP_COUNT traceability gap(s) detected (fail-on-gap=false)."
+          fi
+
+      - name: Upload matrix artifact
+        if: "!inputs.skip && always()"
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
-          name: traceability-matrix
-          path: /tmp/traceability-matrix.html
+          name: traceability-matrix-${{ inputs.version }}
+          path: /tmp/traceability-out/
           retention-days: 90
+          if-no-files-found: ignore
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## ✅ IEC 62304 Traceability Check Passed
+        if: "!inputs.skip && github.event_name == 'pull_request'"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          GAP_COUNT="${{ steps.gaps.outputs.gap_count }}"
+          if [ "${GAP_COUNT:-0}" = "0" ]; then
+            STATUS="✅ All IEC 62304 traceability checks passed."
+          else
+            STATUS="⚠️ ${GAP_COUNT} traceability gap(s) detected — see workflow logs."
+          fi
+          REPORT=$(head -30 /tmp/gap-report.txt 2>/dev/null || echo "(no report)")
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "## IEC 62304 Traceability
 
-- ✅ All software requirements have test coverage
-- ✅ Code coverage meets Class ${{ env.CLASS }} minimum
-- ✅ Traceability matrix validated
-- ✅ Risk controls verified
+          $STATUS
 
-**Artifacts**:
-- [Traceability Matrix](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          | Field | Value |
+          |---|---|
+          | DHF path | \`${{ inputs.dhf-path }}\` |
+          | Version | \`${{ inputs.version }}\` |
+          | Gaps | ${GAP_COUNT:-0} |
 
-See \`dhf/verification/unit-test-map.yaml\` for full mapping.`
-            })
+          <details><summary>Gap report</summary>
 
-      - name: Summary
+          \`\`\`
+          $REPORT
+          \`\`\`
+
+          </details>
+
+          _Powered by \`reusable-iec62304-traceability.yml\`_" 2>/dev/null \
+            || echo "::warning::Could not post PR comment"
+
+      - name: Step summary
         if: always()
         run: |
-          echo "=== IEC 62304 Traceability Summary ==="
-          echo "Class: $CLASS"
-          echo "Check: PASS"
-          echo "Artifacts: traceability-matrix.html"
+          GAP_COUNT="${{ steps.gaps.outputs.gap_count }}"
+          echo "## IEC 62304 Traceability Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| DHF path | \`${{ inputs.dhf-path }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Version | \`${{ inputs.version }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Gaps | ${GAP_COUNT:-0} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f /tmp/gap-report.txt ]; then
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+            cat /tmp/gap-report.txt >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/compliance/dhf-guide.md
+++ b/docs/compliance/dhf-guide.md
@@ -1,0 +1,240 @@
+# Design History File (DHF) Guide
+
+This guide explains how to populate and maintain the DHF YAML files that feed the IEC 62304 traceability workflow.
+
+---
+
+## When do I need a DHF?
+
+Any repository whose `iec62304-class` custom property is set to `class-a`, `class-b`, or `class-c` must maintain a DHF. See `docs/governance/custom-properties.md` for how to set this property and who can approve the change.
+
+| Class | Risk | DHF scope |
+|---|---|---|
+| A | No injury possible | Traceability optional but encouraged |
+| B | Non-serious injury possible | Full traceability required |
+| C | Death or serious injury possible | Full traceability + additional risk controls |
+
+---
+
+## Quick start (new clinical repo)
+
+```bash
+# 1. Copy the DHF template into your repo
+cp -r templates/dhf/ dhf/
+
+# 2. Set the IEC 62304 class in classification.md
+$EDITOR dhf/classification.md
+
+# 3. Replace the stub requirements (SW-001) with real ones
+$EDITOR dhf/requirements/software-requirements.yaml
+
+# 4. Replace the stub hazard (HZ-001) with real hazards
+$EDITOR dhf/risk/hazard-analysis.yaml
+
+# 5. Map tests to requirements
+$EDITOR dhf/verification/unit-test-map.yaml
+
+# 6. Check for gaps (install pyyaml and jsonschema first)
+python scripts/traceability/check_gaps.py --dhf dhf
+
+# 7. Add to your CI workflow
+```
+
+Add to `.github/workflows/ci.yml`:
+
+```yaml
+traceability:
+  uses: ruralpeds/.github/.github/workflows/reusable-iec62304-traceability.yml@main
+  with:
+    dhf-path: dhf
+    fail-on-gap: true
+  permissions:
+    contents: read
+    pull-requests: write
+```
+
+---
+
+## DHF file structure
+
+```
+dhf/
+├── classification.md                          # IEC 62304 class A/B/C decision record
+├── requirements/
+│   └── software-requirements.yaml            # SW-NNN requirements
+├── risk/
+│   └── hazard-analysis.yaml                  # HZ-NNN hazards + RC-NNN controls
+└── verification/
+    └── unit-test-map.yaml                     # UT-NNN tests → SW-NNN mapping
+```
+
+Multiple YAML files are supported in each directory. The traceability scripts merge them all.
+
+---
+
+## ID conventions
+
+| Prefix | Entity | Pattern | Example |
+|---|---|---|---|
+| `SW-NNN` | Software requirement | `SW-\d{3,}` | `SW-001` |
+| `SYS-NNN` | System requirement (parent) | `SYS-\d{3,}` | `SYS-001` |
+| `HZ-NNN` | Hazard | `HZ-\d{3,}` | `HZ-001` |
+| `RC-NNN` | Risk control | `RC-\d{3,}` | `RC-001` |
+| `UT-NNN` | Unit test | `UT-\d{3,}` | `UT-001` |
+
+**Rules:**
+- Never delete an ID — mark it `status: retired` instead
+- IDs must be unique across all files in the repo
+- Use at least 3 digits; pad with leading zeros
+
+---
+
+## Writing good requirements (SW-NNN)
+
+Good requirements are:
+- **Verifiable** — you can write a test that definitively passes or fails
+- **Atomic** — one requirement, one behavior
+- **Implementation-independent** — describes WHAT, not HOW
+
+```yaml
+# Good:
+- id: SW-001
+  title: "System shall reject gestational age below 22 weeks"
+  status: active
+  risk_controls: [RC-001]
+
+# Bad (not verifiable, too vague):
+- id: SW-001
+  title: "System should handle invalid inputs properly"
+```
+
+### Requirement statuses
+
+| Status | Meaning |
+|---|---|
+| `draft` | Under authoring; not yet active; not required to be tested |
+| `active` | Approved and in scope; must have at least one test |
+| `retired` | No longer applies; must NOT be deleted |
+
+---
+
+## Risk analysis (HZ-NNN, RC-NNN)
+
+Each hazard entry has:
+
+1. **Initial risk** — severity × probability before any controls
+2. **Risk controls** (RC-NNN) — measures that reduce risk
+3. **Residual risk** — severity × probability after controls
+
+```yaml
+hazards:
+  - id: HZ-001
+    title: "Incorrect GA used in clinical calculation"
+    severity: serious        # initial severity
+    probability: occasional  # initial probability
+    risk_level: alarp        # initial risk level
+    controls:
+      - id: RC-001
+        title: "Input validation rejects GA < 22w"
+        type: protective-measure  # inherent-safety | protective-measure | information-for-safety
+    severity_residual: negligible
+    probability_residual: incredible
+    risk_level_residual: acceptable
+```
+
+**Traceability rule**: every `RC-NNN` cited in `hazard-analysis.yaml` must also appear in `software-requirements.yaml` under `risk_controls:` for at least one requirement. This ensures every risk control is implemented by testable code.
+
+---
+
+## Mapping tests to requirements (UT-NNN)
+
+```yaml
+tests:
+  - id: UT-001
+    title: "Test GA validation rejects below 22 weeks"
+    file: "tests/test_validation.py"  # relative path
+    symbol: "test_rejects_below_22w"  # test function name
+    verifies:
+      - SW-001
+    status: active
+```
+
+A single test may verify multiple requirements. A single requirement may be verified by multiple tests.
+
+---
+
+## Common pitfalls
+
+**Retired vs. deleted requirements**
+Never delete `SW-NNN` entries. Mark them `status: retired`. The traceability script warns if an active test cites a retired requirement.
+
+**ID reuse**
+Never reuse a retired ID for a new requirement. The ID space is permanent.
+
+**Coverage vs. traceability**
+Code coverage (lines/branches executed) is not the same as traceability (requirements verified). A requirement may have 100% code coverage but no explicit test-to-requirement mapping. Both are required.
+
+**Draft requirements**
+Draft requirements are NOT required to have tests. Set `status: active` only when the requirement is approved and the corresponding test exists or is planned for the sprint.
+
+**Orphan risk controls**
+Every RC-NNN must be referenced by at least one SW-NNN. If a risk control is implemented but not tied to a requirement, add a requirement that captures the behavior and cites the RC.
+
+---
+
+## Running the traceability tools locally
+
+```bash
+# Install dependencies
+pip install pyyaml jsonschema
+
+# Check for gaps (exits non-zero if any gap found)
+python scripts/traceability/check_gaps.py --dhf dhf
+
+# Build the HTML + JSON traceability matrix
+python scripts/traceability/build_matrix.py \
+  --dhf dhf \
+  --version HEAD \
+  --out /tmp/matrix/
+open /tmp/matrix/traceability-matrix.html
+```
+
+---
+
+## How the CI workflow fits in
+
+```
+PR opened
+    │
+    ▼
+reusable-iec62304-traceability.yml
+    │
+    ├── build_matrix.py → traceability-matrix.json + .html  (uploaded as artifact)
+    │
+    ├── check_gaps.py   → exits 0 (pass) or 1 (gaps)
+    │       │
+    │       └── if fail-on-gap=true: blocks PR merge
+    │
+    └── PR comment posted with gap count and report
+```
+
+The matrix artifact is retained 90 days and is attached to every PR and release run for audit purposes.
+
+---
+
+## Cutting a release with DHF bound
+
+1. Ensure `check_gaps.py` exits 0 on the release branch.
+2. The `reusable-release.yml` workflow generates and attaches the traceability matrix to the GitHub Release.
+3. For class-b/c, the matrix artifact is also included in the validation export (`reusable-validation-export.yml`).
+4. After release, commit the generated `dhf/releases/<version>/` directory to the DHF history.
+
+---
+
+## Phase dependencies
+
+| Phase | DHF requirement |
+|---|---|
+| Phase 3 — Rulesets | `iec62304-class` must be set |
+| Phase 6 — DHF scaffold | DHF files must exist and pass `check_gaps.py` |
+| Phase 8 — HA patterns | Class ≥ `clinical-decision` or class-b/c |

--- a/policies/dhf/schemas/hazard-analysis.schema.json
+++ b/policies/dhf/schemas/hazard-analysis.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ruralpeds.github.io/schemas/dhf/hazard-analysis.schema.json",
+  "title": "ISO 14971 Hazard Analysis",
+  "description": "Schema for dhf/risk/hazard-analysis.yaml",
+  "type": "object",
+  "required": ["version", "hazards"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "type": "string" },
+    "hazards": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/hazard" }
+    }
+  },
+  "$defs": {
+    "severity": {
+      "type": "string",
+      "enum": ["negligible", "minor", "serious", "critical", "catastrophic"]
+    },
+    "probability": {
+      "type": "string",
+      "enum": ["frequent", "probable", "occasional", "remote", "improbable", "incredible"]
+    },
+    "risk_level": {
+      "type": "string",
+      "enum": ["unacceptable", "alarp", "acceptable"]
+    },
+    "risk_control": {
+      "type": "object",
+      "required": ["id", "title", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^RC-\\d{3,}$"
+        },
+        "title": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": ["inherent-safety", "protective-measure", "information-for-safety"]
+        },
+        "description": { "type": "string" },
+        "implemented_in": { "type": "string", "description": "Relative file path" }
+      }
+    },
+    "hazard": {
+      "type": "object",
+      "required": ["id", "title", "severity", "probability", "risk_level", "controls"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^HZ-\\d{3,}$"
+        },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "hazardous_situation": { "type": "string" },
+        "harm": { "type": "string" },
+        "severity": { "$ref": "#/$defs/severity" },
+        "probability": { "$ref": "#/$defs/probability" },
+        "risk_level": { "$ref": "#/$defs/risk_level" },
+        "controls": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/risk_control" },
+          "description": "Risk control measures (RC-### objects)"
+        },
+        "severity_residual": { "$ref": "#/$defs/severity" },
+        "probability_residual": { "$ref": "#/$defs/probability" },
+        "risk_level_residual": { "$ref": "#/$defs/risk_level" },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/policies/dhf/schemas/requirements.schema.json
+++ b/policies/dhf/schemas/requirements.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ruralpeds.github.io/schemas/dhf/requirements.schema.json",
+  "title": "IEC 62304 Software Requirements",
+  "description": "Schema for dhf/requirements/software-requirements.yaml",
+  "type": "object",
+  "required": ["version", "requirements"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version (e.g. '1.0')"
+    },
+    "requirements": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/requirement" },
+      "minItems": 0
+    }
+  },
+  "$defs": {
+    "requirement": {
+      "type": "object",
+      "required": ["id", "title", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^SW-\\d{3,}$",
+          "description": "Unique software requirement ID (e.g. SW-001)"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 5
+        },
+        "description": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "active", "retired"],
+          "description": "Lifecycle status; retired reqs should not be tested"
+        },
+        "parent": {
+          "type": "string",
+          "pattern": "^SYS-\\d{3,}$",
+          "description": "Parent system requirement ID (optional)"
+        },
+        "risk_controls": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^RC-\\d{3,}$"
+          },
+          "description": "Risk control IDs that this requirement implements"
+        },
+        "implemented": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "location": { "type": "string", "description": "Relative file path" },
+            "symbol": { "type": "string", "description": "Function or type name" }
+          }
+        },
+        "rationale": { "type": "string" },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/policies/dhf/schemas/unit-test-map.schema.json
+++ b/policies/dhf/schemas/unit-test-map.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ruralpeds.github.io/schemas/dhf/unit-test-map.schema.json",
+  "title": "IEC 62304 Unit Test Map",
+  "description": "Schema for dhf/verification/unit-test-map.yaml — maps tests to software requirements",
+  "type": "object",
+  "required": ["version", "tests"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "type": "string" },
+    "tests": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/test_entry" }
+    }
+  },
+  "$defs": {
+    "test_entry": {
+      "type": "object",
+      "required": ["id", "title", "verifies"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^UT-\\d{3,}$"
+        },
+        "title": { "type": "string" },
+        "file": { "type": "string", "description": "Relative path to test file" },
+        "symbol": { "type": "string", "description": "Test function or method name" },
+        "verifies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^SW-\\d{3,}$"
+          },
+          "minItems": 1,
+          "description": "SW-### requirement IDs this test verifies"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["active", "retired"],
+          "default": "active"
+        },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/scripts/traceability/build_matrix.py
+++ b/scripts/traceability/build_matrix.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Build IEC 62304 traceability matrix from DHF YAML files.
+
+Reads dhf/requirements/*.yaml, dhf/risk/*.yaml, and dhf/verification/*.yaml;
+validates against JSON schemas; emits traceability-matrix.json and
+traceability-matrix.html.
+
+Usage:
+    python scripts/traceability/build_matrix.py \\
+        --dhf dhf \\
+        --version HEAD \\
+        --out dhf/releases/HEAD/
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML is required: pip install pyyaml")
+
+try:
+    import jsonschema
+except ImportError:
+    sys.exit("jsonschema is required: pip install jsonschema")
+
+SCHEMA_DIR = Path(__file__).parent.parent.parent / "policies" / "dhf" / "schemas"
+
+SEVERITY_ORDER = ["negligible", "minor", "serious", "critical", "catastrophic"]
+SERIOUS_AND_ABOVE = {"serious", "critical", "catastrophic"}
+
+
+def load_yaml(path: Path) -> dict | list:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def validate(data: dict, schema_path: Path, source: Path) -> None:
+    schema = json.loads(schema_path.read_text())
+    try:
+        jsonschema.validate(data, schema)
+    except jsonschema.ValidationError as e:
+        print(f"  Schema error in {source}: {e.message} at {list(e.path)}")
+        raise
+
+
+def load_dhf(dhf_path: Path) -> tuple[list, list, list]:
+    reqs, hazards, tests = [], [], []
+
+    for f in sorted(dhf_path.glob("requirements/*.yaml")):
+        data = load_yaml(f)
+        validate(data, SCHEMA_DIR / "requirements.schema.json", f)
+        reqs.extend(data.get("requirements", []))
+
+    for f in sorted(dhf_path.glob("risk/*.yaml")):
+        data = load_yaml(f)
+        validate(data, SCHEMA_DIR / "hazard-analysis.schema.json", f)
+        hazards.extend(data.get("hazards", []))
+
+    for f in sorted(dhf_path.glob("verification/*.yaml")):
+        data = load_yaml(f)
+        validate(data, SCHEMA_DIR / "unit-test-map.schema.json", f)
+        tests.extend(data.get("tests", []))
+
+    return reqs, hazards, tests
+
+
+def build_matrix(reqs: list, hazards: list, tests: list) -> dict:
+    test_by_sw: dict[str, list[str]] = {}
+    for t in tests:
+        if t.get("status", "active") == "retired":
+            continue
+        for sw_id in t.get("verifies", []):
+            test_by_sw.setdefault(sw_id, []).append(t["id"])
+
+    rc_to_sw: dict[str, list[str]] = {}
+    for req in reqs:
+        for rc in req.get("risk_controls", []):
+            rc_to_sw.setdefault(rc, []).append(req["id"])
+
+    req_rows = []
+    for req in reqs:
+        sw_id = req["id"]
+        tests_list = test_by_sw.get(sw_id, [])
+        row = {
+            "id": sw_id,
+            "title": req.get("title", ""),
+            "status": req.get("status", "active"),
+            "parent": req.get("parent"),
+            "risk_controls": req.get("risk_controls", []),
+            "tests": tests_list,
+            "tested": len(tests_list) > 0,
+            "implemented": bool(req.get("implemented")),
+        }
+        req_rows.append(row)
+
+    hazard_rows = []
+    for hz in hazards:
+        controls = hz.get("controls", [])
+        rc_ids = [c["id"] if isinstance(c, dict) else c for c in controls]
+        any_rc_in_sw = any(rc in rc_to_sw for rc in rc_ids)
+        residual_severity = hz.get("severity_residual", hz.get("severity", ""))
+        row = {
+            "id": hz["id"],
+            "title": hz.get("title", ""),
+            "severity": hz.get("severity", ""),
+            "probability": hz.get("probability", ""),
+            "risk_level": hz.get("risk_level", ""),
+            "controls": rc_ids,
+            "controls_in_requirements": any_rc_in_sw,
+            "severity_residual": residual_severity,
+            "risk_level_residual": hz.get("risk_level_residual", ""),
+        }
+        hazard_rows.append(row)
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "requirements": req_rows,
+        "hazards": hazard_rows,
+        "summary": {
+            "total_requirements": len(req_rows),
+            "tested_requirements": sum(1 for r in req_rows if r["tested"]),
+            "total_hazards": len(hazard_rows),
+            "hazards_controlled": sum(1 for h in hazard_rows if h["controls"]),
+        },
+    }
+
+
+def render_html(matrix: dict, version: str) -> str:
+    req_rows = ""
+    for r in matrix["requirements"]:
+        status_class = "pass" if r["tested"] else "fail"
+        tests_cell = ", ".join(r["tests"]) if r["tests"] else "—"
+        rc_cell = ", ".join(r["risk_controls"]) if r["risk_controls"] else "—"
+        req_rows += (
+            f"<tr>"
+            f"<td>{r['id']}</td>"
+            f"<td>{r['title']}</td>"
+            f"<td>{r['status']}</td>"
+            f"<td>{r['parent'] or '—'}</td>"
+            f"<td class='{status_class}'>{tests_cell}</td>"
+            f"<td>{rc_cell}</td>"
+            f"</tr>\n"
+        )
+
+    hz_rows = ""
+    for h in matrix["hazards"]:
+        ctrl_class = "pass" if h["controls_in_requirements"] else "fail"
+        controls_cell = ", ".join(h["controls"]) if h["controls"] else "—"
+        hz_rows += (
+            f"<tr>"
+            f"<td>{h['id']}</td>"
+            f"<td>{h['title']}</td>"
+            f"<td>{h['severity']}</td>"
+            f"<td>{h['probability']}</td>"
+            f"<td>{h['risk_level']}</td>"
+            f"<td class='{ctrl_class}'>{controls_cell}</td>"
+            f"<td>{h['severity_residual']}</td>"
+            f"<td>{h['risk_level_residual']}</td>"
+            f"</tr>\n"
+        )
+
+    s = matrix["summary"]
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Traceability Matrix — {version}</title>
+<style>
+body{{font-family:system-ui,sans-serif;margin:2rem;color:#111}}
+h1{{font-size:1.5rem}}h2{{font-size:1.2rem;margin-top:2rem}}
+table{{border-collapse:collapse;width:100%;font-size:.875rem}}
+th{{background:#2d3748;color:#fff;padding:.5rem .75rem;text-align:left}}
+td{{padding:.4rem .75rem;border-bottom:1px solid #e2e8f0}}
+tr:hover td{{background:#f7fafc}}
+.pass{{color:#276749;font-weight:600}}
+.fail{{color:#c53030;font-weight:600}}
+.summary{{display:flex;gap:2rem;margin:1rem 0}}
+.stat{{background:#edf2f7;border-radius:.5rem;padding:.75rem 1.25rem;text-align:center}}
+.stat-value{{font-size:1.75rem;font-weight:700}}
+.stat-label{{font-size:.75rem;color:#718096}}
+</style>
+<script>
+function sortTable(n,el){{
+  var t=el.closest('table'),rows=Array.from(t.querySelectorAll('tbody tr'));
+  var asc=el.dataset.asc=el.dataset.asc!='1'?'1':'0';
+  rows.sort((a,b)=>{{
+    var av=a.cells[n].textContent,bv=b.cells[n].textContent;
+    return asc=='1'?av.localeCompare(bv):bv.localeCompare(av);
+  }});
+  t.querySelector('tbody').append(...rows);
+}}
+</script>
+</head>
+<body>
+<h1>IEC 62304 Traceability Matrix</h1>
+<p><strong>Version:</strong> {version} &nbsp; <strong>Generated:</strong> {matrix['generated_at'][:19]}Z</p>
+<div class="summary">
+  <div class="stat"><div class="stat-value">{s['total_requirements']}</div><div class="stat-label">Requirements</div></div>
+  <div class="stat"><div class="stat-value">{s['tested_requirements']}</div><div class="stat-label">Tested</div></div>
+  <div class="stat"><div class="stat-value">{s['total_hazards']}</div><div class="stat-label">Hazards</div></div>
+  <div class="stat"><div class="stat-value">{s['hazards_controlled']}</div><div class="stat-label">Controlled</div></div>
+</div>
+
+<h2>Software Requirements (IEC 62304 §5.2)</h2>
+<table>
+<thead><tr>
+  <th onclick="sortTable(0,this)" style="cursor:pointer">ID ↕</th>
+  <th>Title</th><th>Status</th><th>Parent</th>
+  <th onclick="sortTable(4,this)" style="cursor:pointer">Tests ↕</th>
+  <th>Risk Controls</th>
+</tr></thead>
+<tbody>{req_rows}</tbody>
+</table>
+
+<h2>Hazard Analysis (ISO 14971)</h2>
+<table>
+<thead><tr>
+  <th onclick="sortTable(0,this)" style="cursor:pointer">ID ↕</th>
+  <th>Title</th><th>Severity</th><th>Probability</th><th>Risk Level</th>
+  <th onclick="sortTable(5,this)" style="cursor:pointer">Controls ↕</th>
+  <th>Residual Severity</th><th>Residual Risk</th>
+</tr></thead>
+<tbody>{hz_rows}</tbody>
+</table>
+</body>
+</html>"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dhf", default="dhf", help="Path to DHF directory")
+    parser.add_argument("--version", default="HEAD", help="Version label for outputs")
+    parser.add_argument("--out", required=True, help="Output directory")
+    args = parser.parse_args()
+
+    dhf_path = Path(args.dhf)
+    out_path = Path(args.out)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    reqs, hazards, tests = load_dhf(dhf_path)
+    matrix = build_matrix(reqs, hazards, tests)
+
+    json_path = out_path / "traceability-matrix.json"
+    html_path = out_path / "traceability-matrix.html"
+
+    json_path.write_text(json.dumps(matrix, indent=2))
+    html_path.write_text(render_html(matrix, args.version))
+
+    s = matrix["summary"]
+    print(
+        f"Matrix written to {out_path}/\n"
+        f"  Requirements: {s['total_requirements']} total, "
+        f"{s['tested_requirements']} tested\n"
+        f"  Hazards: {s['total_hazards']} total, "
+        f"{s['hazards_controlled']} with controls"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/traceability/check_gaps.py
+++ b/scripts/traceability/check_gaps.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Check IEC 62304 traceability gaps in DHF YAML files.
+
+Rules:
+  1. Every non-retired, non-draft SW-### must have >= 1 active test in unit-test-map.yaml
+  2. Every HZ-### with residual severity >= serious must have >= 1 risk control
+  3. Every RC-### cited from a hazard must be cited by >= 1 SW-### requirement
+  4. No duplicate IDs (across all files)
+  5. WARN (not fail): active test cites a retired requirement
+
+Exit codes:
+  0 — all checks pass (warnings may still be printed)
+  1 — hard gap (missing test, missing RC, orphan RC)
+  2 — schema / parse error
+
+Usage:
+    python scripts/traceability/check_gaps.py --dhf dhf
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML is required: pip install pyyaml")
+
+SERIOUS_AND_ABOVE = {"serious", "critical", "catastrophic"}
+
+
+def load_yaml(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def load_dhf(dhf_path: Path) -> tuple[list[dict], list[dict], list[dict]]:
+    reqs, hazards, tests = [], [], []
+    for f in sorted(dhf_path.glob("requirements/*.yaml")):
+        data = load_yaml(f)
+        for r in data.get("requirements", []):
+            r.setdefault("_source", str(f))
+            reqs.append(r)
+    for f in sorted(dhf_path.glob("risk/*.yaml")):
+        data = load_yaml(f)
+        for h in data.get("hazards", []):
+            h.setdefault("_source", str(f))
+            hazards.append(h)
+    for f in sorted(dhf_path.glob("verification/*.yaml")):
+        data = load_yaml(f)
+        for t in data.get("tests", []):
+            t.setdefault("_source", str(f))
+            tests.append(t)
+    return reqs, hazards, tests
+
+
+def check(dhf_path: Path) -> int:
+    try:
+        reqs, hazards, tests = load_dhf(dhf_path)
+    except Exception as e:
+        print(f"ERROR parsing DHF files: {e}", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # ── Check 1: duplicate IDs ─────────────────────────────────────────────
+    seen_ids: dict[str, str] = {}
+    for r in reqs:
+        rid = r.get("id", "")
+        if rid in seen_ids:
+            errors.append(f"Duplicate ID {rid!r} in {r['_source']} (first seen in {seen_ids[rid]})")
+        else:
+            seen_ids[rid] = r["_source"]
+
+    for h in hazards:
+        hid = h.get("id", "")
+        if hid in seen_ids:
+            errors.append(f"Duplicate ID {hid!r} in {h['_source']} (first seen in {seen_ids[hid]})")
+        else:
+            seen_ids[hid] = h["_source"]
+        for c in h.get("controls", []):
+            rc_id = c["id"] if isinstance(c, dict) else c
+            rc_src = f"{h['_source']}[{hid}.controls]"
+            if rc_id in seen_ids and not rc_id.startswith("RC-"):
+                errors.append(f"Duplicate ID {rc_id!r} at {rc_src}")
+            elif rc_id not in seen_ids:
+                seen_ids[rc_id] = rc_src
+
+    for t in tests:
+        tid = t.get("id", "")
+        if tid in seen_ids:
+            errors.append(f"Duplicate ID {tid!r} in {t['_source']} (first seen in {seen_ids[tid]})")
+        else:
+            seen_ids[tid] = t["_source"]
+
+    # ── Build lookup tables ────────────────────────────────────────────────
+    req_by_id: dict[str, dict] = {r["id"]: r for r in reqs if "id" in r}
+    retired_sw = {r["id"] for r in reqs if r.get("status") == "retired"}
+
+    tested_sw: dict[str, list[str]] = {}
+    for t in tests:
+        if t.get("status", "active") == "retired":
+            continue
+        for sw_id in t.get("verifies", []):
+            tested_sw.setdefault(sw_id, []).append(t["id"])
+
+    rc_to_sw: dict[str, list[str]] = {}
+    for r in reqs:
+        for rc in r.get("risk_controls", []):
+            rc_to_sw.setdefault(rc, []).append(r["id"])
+
+    # ── Check 2: every active SW must have a test ─────────────────────────
+    for r in reqs:
+        sw_id = r.get("id", "")
+        status = r.get("status", "active")
+        if status in ("retired", "draft"):
+            continue
+        if sw_id not in tested_sw:
+            errors.append(
+                f"MISSING TEST: {sw_id} ({r.get('title', '')!r}) "
+                f"in {r['_source']} has no active test in unit-test-map.yaml"
+            )
+
+    # ── Check 3: serious+ hazards must have controls ──────────────────────
+    for h in hazards:
+        hz_id = h.get("id", "")
+        residual = h.get("severity_residual", h.get("severity", "negligible"))
+        controls = h.get("controls", [])
+        rc_ids = [c["id"] if isinstance(c, dict) else c for c in controls]
+        if residual in SERIOUS_AND_ABOVE and not rc_ids:
+            errors.append(
+                f"MISSING CONTROL: {hz_id} ({h.get('title', '')!r}) "
+                f"has residual severity={residual!r} but no risk controls in {h['_source']}"
+            )
+
+    # ── Check 4: every RC cited by a hazard must be cited by a SW req ─────
+    for h in hazards:
+        hz_id = h.get("id", "")
+        for c in h.get("controls", []):
+            rc_id = c["id"] if isinstance(c, dict) else c
+            if rc_id not in rc_to_sw:
+                errors.append(
+                    f"ORPHAN CONTROL: {rc_id} cited by {hz_id} ({h['_source']}) "
+                    f"is not referenced by any SW-### requirement"
+                )
+
+    # ── Check 5 (warn): active test cites retired requirement ─────────────
+    for t in tests:
+        if t.get("status", "active") == "retired":
+            continue
+        for sw_id in t.get("verifies", []):
+            if sw_id in retired_sw:
+                warnings.append(
+                    f"WARN: Test {t['id']} ({t['_source']}) "
+                    f"cites retired requirement {sw_id} — consider updating"
+                )
+
+    for w in warnings:
+        print(w)
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    tested_count = sum(1 for r in reqs if r.get("status") == "active" and r.get("id") in tested_sw)
+    active_count = sum(1 for r in reqs if r.get("status") == "active")
+    print(
+        f"All checks passed: {active_count} active requirements "
+        f"({tested_count} tested), {len(hazards)} hazards"
+    )
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dhf", default="dhf", help="Path to DHF directory")
+    args = parser.parse_args()
+    sys.exit(check(Path(args.dhf)))
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/dhf/README.md
+++ b/templates/dhf/README.md
@@ -1,0 +1,69 @@
+# DHF Template
+
+This directory contains the Design History File (DHF) scaffold for IEC 62304-classified repositories.
+
+## Quick start
+
+```bash
+# Copy this template into your clinical repo
+cp -r templates/dhf/ <your-repo>/dhf/
+
+# Edit classification.md with your software's class
+# Edit requirements/software-requirements.yaml — replace SW-001 stub
+# Edit risk/hazard-analysis.yaml — replace HZ-001 stub
+# Edit verification/unit-test-map.yaml — replace UT-001 stub
+
+# Check traceability gaps (install pyyaml jsonschema first)
+python scripts/traceability/check_gaps.py --dhf dhf
+```
+
+## Directory structure
+
+```
+dhf/
+├── requirements/
+│   └── software-requirements.yaml   # IEC 62304 §5.2 — SW-NNN requirements
+├── risk/
+│   └── hazard-analysis.yaml         # ISO 14971 — HZ-NNN hazards + RC-NNN controls
+├── verification/
+│   └── unit-test-map.yaml           # IEC 62304 §5.5 — UT-NNN to SW-NNN mapping
+└── classification.md                # IEC 62304 class A/B/C decision record
+```
+
+## ID conventions
+
+| Prefix | Entity | Example |
+|---|---|---|
+| `SW-NNN` | Software requirement | `SW-001` |
+| `SYS-NNN` | System requirement (parent) | `SYS-001` |
+| `HZ-NNN` | Hazard | `HZ-001` |
+| `RC-NNN` | Risk control | `RC-001` |
+| `UT-NNN` | Unit test | `UT-001` |
+
+Use at least 3 digits. Never reuse an ID — retire instead of deleting.
+
+## Schemas
+
+YAML files reference schemas for IDE validation. Install the YAML Language Server extension
+and schemas are enforced as you type:
+
+```
+$schema: ../../../policies/dhf/schemas/requirements.schema.json
+```
+
+## CI integration
+
+Add to `.github/workflows/ci.yml`:
+
+```yaml
+traceability:
+  uses: ruralpeds/.github/.github/workflows/reusable-iec62304-traceability.yml@main
+  with:
+    dhf-path: dhf
+    fail-on-gap: true
+  permissions:
+    contents: read
+    pull-requests: write
+```
+
+See `docs/compliance/dhf-guide.md` for complete documentation.

--- a/templates/dhf/classification.md
+++ b/templates/dhf/classification.md
@@ -1,0 +1,51 @@
+# IEC 62304 Software Classification
+
+**Repository:** `<owner>/<repo>`
+**Classification date:** YYYY-MM-DD
+**Classified by:** `<github-username>`
+**Reviewed by:** `<github-username>` (clinical lead)
+
+---
+
+## Classification decision
+
+| Property | Value |
+|---|---|
+| IEC 62304 class | `class-b` *(replace with actual class)* |
+| Regulated | `true` / `false` |
+| Data classification | `phi-active` / `phi-capable` / `internal` |
+| Criticality | `clinical-decision` / `clinical-support` |
+
+## Rationale
+
+**Class A** — No injury possible: software failure cannot lead to patient harm, even indirectly.
+
+**Class B** — Non-serious injury possible: software failure could lead to a non-serious injury.
+
+**Class C** — Death or serious injury possible: software failure could lead to death or serious injury.
+
+### Selected: `class-[A/B/C]` because:
+
+*[Replace this section with the reasoning: describe the role this software plays in the clinical
+workflow, the worst-case failure mode, and why that failure mode maps to the selected class.
+Reference IEC 62304:2006+A1:2015 Table 1 and the relevant ISO 14971 risk analysis.]*
+
+---
+
+## Scope
+
+This classification applies to software components:
+
+- *[List the modules, libraries, or services included in scope]*
+
+The following components are **excluded** from this classification (and their rationale):
+
+- *[e.g., "Test infrastructure (pytest fixtures) — not deployed to production"]*
+
+---
+
+## Change history
+
+| Date | Change | Author |
+|---|---|---|
+| YYYY-MM-DD | Initial classification | `<username>` |

--- a/templates/dhf/requirements/software-requirements.yaml
+++ b/templates/dhf/requirements/software-requirements.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=../../../policies/dhf/schemas/requirements.schema.json
+#
+# Software Requirements Specification — IEC 62304 §5.2
+#
+# Instructions:
+#   1. Replace SW-001 with your actual requirements.
+#   2. Set status: draft during initial authoring; active before the first release.
+#   3. Never delete requirements — mark them status: retired instead.
+#   4. For each requirement that implements a risk control, add the RC-### to risk_controls.
+#   5. Run `python scripts/traceability/check_gaps.py --dhf dhf` to check coverage.
+
+version: "1.0"
+requirements:
+
+  - id: SW-001
+    title: "[REPLACE] System shall validate <input> before processing"
+    description: >
+      Replace this with a precise, verifiable requirement.
+      Good requirements are testable: you must be able to write a test that
+      definitively passes or fails against this statement.
+    status: draft          # draft | active | retired
+    parent: SYS-001        # optional — parent system requirement ID
+    risk_controls: []      # e.g. [RC-001] if this req implements a risk control
+    implemented:
+      location: "src/todo.rs"   # relative path to the implementing file
+      symbol: "todo_function"   # function/type name
+    rationale: >
+      Brief explanation of why this requirement exists and any regulatory
+      reference (e.g., "Per ACOG guidelines, 22 weeks is the minimum
+      viable gestational age for this calculation").
+
+  # Add more requirements below. Do NOT delete this stub — retire it instead.

--- a/templates/dhf/risk/hazard-analysis.yaml
+++ b/templates/dhf/risk/hazard-analysis.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=../../../policies/dhf/schemas/hazard-analysis.schema.json
+#
+# Hazard Analysis — ISO 14971:2019 §5
+#
+# Each hazard must have:
+#   - A unique ID in the format HZ-NNN
+#   - Severity and probability BEFORE risk controls (initial)
+#   - Risk controls (RC-NNN objects) with type: inherent-safety, protective-measure, or information-for-safety
+#   - Severity and risk level AFTER risk controls (residual)
+#
+# Severity scale: negligible | minor | serious | critical | catastrophic
+# Probability:    frequent | probable | occasional | remote | improbable | incredible
+# Risk level:     unacceptable | alarp | acceptable
+#
+# Traceability rule: every RC-NNN listed here must also appear in
+# requirements/software-requirements.yaml under `risk_controls:` for at least one SW-NNN.
+
+version: "1.0"
+hazards:
+
+  - id: HZ-001
+    title: "[REPLACE] System accepts invalid <input>"
+    description: "[REPLACE] Describe the hazardous condition."
+    hazardous_situation: "[REPLACE] Describe what happens when the hazard occurs."
+    harm: "[REPLACE] Describe the patient harm that could result."
+
+    # Initial risk (before controls)
+    severity: serious          # negligible | minor | serious | critical | catastrophic
+    probability: occasional    # frequent | probable | occasional | remote | improbable | incredible
+    risk_level: alarp          # unacceptable | alarp | acceptable
+
+    # Risk controls — each RC-NNN must be referenced by a SW-NNN requirement
+    controls:
+      - id: RC-001
+        title: "[REPLACE] Input validation gate"
+        type: protective-measure   # inherent-safety | protective-measure | information-for-safety
+        description: "[REPLACE] Describe what this control does."
+        implemented_in: "src/validation.rs"  # optional: relative path
+
+    # Residual risk (after controls are applied)
+    severity_residual: negligible
+    probability_residual: incredible
+    risk_level_residual: acceptable
+
+  # Add more hazards below. The template HZ-001 entry should be replaced or retired.

--- a/templates/dhf/verification/unit-test-map.yaml
+++ b/templates/dhf/verification/unit-test-map.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=../../../policies/dhf/schemas/unit-test-map.schema.json
+#
+# Unit Test Map — IEC 62304 §5.5, §5.7
+#
+# Maps test functions to the software requirements they verify.
+# Each active SW-NNN with status != draft or retired must have >= 1 entry here.
+#
+# Notes:
+#   - `file` and `symbol` are informational (not validated by check_gaps.py today;
+#     annotate your source code with @requirement("SW-NNN") for code-level tracing).
+#   - Never delete entries — mark them status: retired instead.
+#   - A test may verify multiple requirements.
+
+version: "1.0"
+tests:
+
+  - id: UT-001
+    title: "[REPLACE] Test that <SW-001> is met"
+    file: "tests/test_todo.py"     # relative path to test file
+    symbol: "test_todo_function"   # test function name
+    verifies:
+      - SW-001                     # The requirement this test verifies
+    status: active                 # active | retired
+    notes: >
+      [REPLACE] Brief description of what this test covers and any
+      test environment requirements.
+
+  # add more tests below — one UT-NNN per test function (or per requirement cluster)

--- a/tests/traceability/fixtures/duplicate-id/requirements/software-requirements.yaml
+++ b/tests/traceability/fixtures/duplicate-id/requirements/software-requirements.yaml
@@ -1,0 +1,9 @@
+version: "1.0"
+requirements:
+  - id: SW-001
+    title: "First requirement"
+    status: active
+    risk_controls: [RC-001]
+  - id: SW-001
+    title: "Duplicate requirement ID"
+    status: active

--- a/tests/traceability/fixtures/duplicate-id/risk/hazard-analysis.yaml
+++ b/tests/traceability/fixtures/duplicate-id/risk/hazard-analysis.yaml
@@ -1,0 +1,11 @@
+version: "1.0"
+hazards:
+  - id: HZ-001
+    title: "Test hazard"
+    severity: negligible
+    probability: incredible
+    risk_level: acceptable
+    controls:
+      - id: RC-001
+        title: "Control"
+        type: protective-measure

--- a/tests/traceability/fixtures/duplicate-id/verification/unit-test-map.yaml
+++ b/tests/traceability/fixtures/duplicate-id/verification/unit-test-map.yaml
@@ -1,0 +1,5 @@
+version: "1.0"
+tests:
+  - id: UT-001
+    title: "Test"
+    verifies: [SW-001]

--- a/tests/traceability/fixtures/missing-test/requirements/software-requirements.yaml
+++ b/tests/traceability/fixtures/missing-test/requirements/software-requirements.yaml
@@ -1,0 +1,9 @@
+version: "1.0"
+requirements:
+  - id: SW-001
+    title: "System shall validate gestational age"
+    status: active
+    risk_controls: [RC-001]
+  - id: SW-002
+    title: "This requirement has no test"
+    status: active

--- a/tests/traceability/fixtures/missing-test/risk/hazard-analysis.yaml
+++ b/tests/traceability/fixtures/missing-test/risk/hazard-analysis.yaml
@@ -1,0 +1,11 @@
+version: "1.0"
+hazards:
+  - id: HZ-001
+    title: "Invalid GA accepted"
+    severity: negligible
+    probability: incredible
+    risk_level: acceptable
+    controls:
+      - id: RC-001
+        title: "Input validation"
+        type: protective-measure

--- a/tests/traceability/fixtures/missing-test/verification/unit-test-map.yaml
+++ b/tests/traceability/fixtures/missing-test/verification/unit-test-map.yaml
@@ -1,0 +1,5 @@
+version: "1.0"
+tests:
+  - id: UT-001
+    title: "Test GA validation"
+    verifies: [SW-001]

--- a/tests/traceability/fixtures/orphan-rc/requirements/software-requirements.yaml
+++ b/tests/traceability/fixtures/orphan-rc/requirements/software-requirements.yaml
@@ -1,0 +1,5 @@
+version: "1.0"
+requirements:
+  - id: SW-001
+    title: "Test requirement"
+    status: active

--- a/tests/traceability/fixtures/orphan-rc/risk/hazard-analysis.yaml
+++ b/tests/traceability/fixtures/orphan-rc/risk/hazard-analysis.yaml
@@ -1,0 +1,11 @@
+version: "1.0"
+hazards:
+  - id: HZ-001
+    title: "Test hazard"
+    severity: negligible
+    probability: incredible
+    risk_level: acceptable
+    controls:
+      - id: RC-001
+        title: "Orphan control (not cited by any requirement)"
+        type: protective-measure

--- a/tests/traceability/fixtures/orphan-rc/verification/unit-test-map.yaml
+++ b/tests/traceability/fixtures/orphan-rc/verification/unit-test-map.yaml
@@ -1,0 +1,5 @@
+version: "1.0"
+tests:
+  - id: UT-001
+    title: "Test SW-001"
+    verifies: [SW-001]

--- a/tests/traceability/fixtures/retired-req-tested/requirements/software-requirements.yaml
+++ b/tests/traceability/fixtures/retired-req-tested/requirements/software-requirements.yaml
@@ -1,0 +1,8 @@
+version: "1.0"
+requirements:
+  - id: SW-001
+    title: "Active requirement"
+    status: active
+  - id: SW-002
+    title: "Retired requirement"
+    status: retired

--- a/tests/traceability/fixtures/retired-req-tested/risk/hazard-analysis.yaml
+++ b/tests/traceability/fixtures/retired-req-tested/risk/hazard-analysis.yaml
@@ -1,0 +1,2 @@
+version: "1.0"
+hazards: []

--- a/tests/traceability/fixtures/retired-req-tested/verification/unit-test-map.yaml
+++ b/tests/traceability/fixtures/retired-req-tested/verification/unit-test-map.yaml
@@ -1,0 +1,8 @@
+version: "1.0"
+tests:
+  - id: UT-001
+    title: "Test active requirement"
+    verifies: [SW-001]
+  - id: UT-002
+    title: "Test retired requirement (should warn)"
+    verifies: [SW-002]

--- a/tests/traceability/fixtures/valid-minimal/requirements/software-requirements.yaml
+++ b/tests/traceability/fixtures/valid-minimal/requirements/software-requirements.yaml
@@ -1,0 +1,9 @@
+version: "1.0"
+requirements:
+  - id: SW-001
+    title: "System shall validate gestational age"
+    status: active
+    risk_controls: [RC-001]
+  - id: SW-002
+    title: "System shall log all user actions"
+    status: active

--- a/tests/traceability/fixtures/valid-minimal/risk/hazard-analysis.yaml
+++ b/tests/traceability/fixtures/valid-minimal/risk/hazard-analysis.yaml
@@ -1,0 +1,14 @@
+version: "1.0"
+hazards:
+  - id: HZ-001
+    title: "Invalid GA accepted"
+    severity: serious
+    probability: occasional
+    risk_level: alarp
+    controls:
+      - id: RC-001
+        title: "Input validation gate"
+        type: protective-measure
+    severity_residual: negligible
+    probability_residual: incredible
+    risk_level_residual: acceptable

--- a/tests/traceability/fixtures/valid-minimal/verification/unit-test-map.yaml
+++ b/tests/traceability/fixtures/valid-minimal/verification/unit-test-map.yaml
@@ -1,0 +1,12 @@
+version: "1.0"
+tests:
+  - id: UT-001
+    title: "Test GA validation rejects below 22w"
+    file: "tests/test_validation.py"
+    symbol: "test_rejects_below_22w"
+    verifies: [SW-001]
+  - id: UT-002
+    title: "Test audit log captures login"
+    file: "tests/test_audit.py"
+    symbol: "test_login_logged"
+    verifies: [SW-002]

--- a/tests/traceability/test_build_matrix.py
+++ b/tests/traceability/test_build_matrix.py
@@ -1,0 +1,101 @@
+"""Unit tests for scripts/traceability/build_matrix.py"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from traceability.build_matrix import build_matrix, load_dhf, render_html
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_load_dhf_valid_minimal():
+    reqs, hazards, tests = load_dhf(FIXTURES / "valid-minimal")
+    assert len(reqs) == 2
+    assert len(hazards) == 1
+    assert len(tests) == 2
+
+
+def test_build_matrix_structure():
+    reqs, hazards, tests = load_dhf(FIXTURES / "valid-minimal")
+    matrix = build_matrix(reqs, hazards, tests)
+    assert "requirements" in matrix
+    assert "hazards" in matrix
+    assert "summary" in matrix
+    assert "generated_at" in matrix
+
+
+def test_build_matrix_tested_flag():
+    reqs, hazards, tests = load_dhf(FIXTURES / "valid-minimal")
+    matrix = build_matrix(reqs, hazards, tests)
+    req_rows = {r["id"]: r for r in matrix["requirements"]}
+    assert req_rows["SW-001"]["tested"] is True
+    assert req_rows["SW-002"]["tested"] is True
+
+
+def test_build_matrix_untested_requirement():
+    reqs, hazards, tests = load_dhf(FIXTURES / "missing-test")
+    matrix = build_matrix(reqs, hazards, tests)
+    req_rows = {r["id"]: r for r in matrix["requirements"]}
+    assert req_rows["SW-001"]["tested"] is True
+    assert req_rows["SW-002"]["tested"] is False
+
+
+def test_build_matrix_summary_counts():
+    reqs, hazards, tests = load_dhf(FIXTURES / "valid-minimal")
+    matrix = build_matrix(reqs, hazards, tests)
+    s = matrix["summary"]
+    assert s["total_requirements"] == 2
+    assert s["tested_requirements"] == 2
+    assert s["total_hazards"] == 1
+    assert s["hazards_controlled"] == 1
+
+
+def test_render_html_produces_string():
+    reqs, hazards, tests = load_dhf(FIXTURES / "valid-minimal")
+    matrix = build_matrix(reqs, hazards, tests)
+    html = render_html(matrix, "test-v1.0")
+    assert isinstance(html, str)
+    assert len(html) > 100
+
+
+def test_render_html_contains_ids():
+    reqs, hazards, tests = load_dhf(FIXTURES / "valid-minimal")
+    matrix = build_matrix(reqs, hazards, tests)
+    html = render_html(matrix, "HEAD")
+    assert "SW-001" in html
+    assert "HZ-001" in html
+
+
+def test_render_html_is_parseable_as_html():
+    """Smoke test: rendered HTML should at least have the basic structure."""
+    reqs, hazards, tests = load_dhf(FIXTURES / "valid-minimal")
+    matrix = build_matrix(reqs, hazards, tests)
+    html = render_html(matrix, "HEAD")
+    assert "<!DOCTYPE html>" in html
+    assert "<table>" in html
+    assert "</html>" in html
+
+
+def test_build_matrix_emits_json(tmp_path):
+    from traceability.build_matrix import main
+    import subprocess, sys
+    result = subprocess.run(
+        [sys.executable, "-m", "traceability.build_matrix",
+         "--dhf", str(FIXTURES / "valid-minimal"),
+         "--version", "test",
+         "--out", str(tmp_path)],
+        cwd=str(Path(__file__).parent.parent.parent / "scripts"),
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    json_file = tmp_path / "traceability-matrix.json"
+    html_file = tmp_path / "traceability-matrix.html"
+    assert json_file.exists()
+    assert html_file.exists()
+    matrix = json.loads(json_file.read_text())
+    assert matrix["summary"]["total_requirements"] == 2

--- a/tests/traceability/test_check_gaps.py
+++ b/tests/traceability/test_check_gaps.py
@@ -1,0 +1,95 @@
+"""Unit tests for scripts/traceability/check_gaps.py"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from traceability.check_gaps import check
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_valid_minimal_passes():
+    assert check(FIXTURES / "valid-minimal") == 0
+
+
+def test_missing_test_fails():
+    assert check(FIXTURES / "missing-test") == 1
+
+
+def test_orphan_rc_fails():
+    assert check(FIXTURES / "orphan-rc") == 1
+
+
+def test_duplicate_id_fails():
+    assert check(FIXTURES / "duplicate-id") == 1
+
+
+def test_retired_req_tested_warns_but_passes():
+    """Active test citing a retired req should warn but exit 0."""
+    assert check(FIXTURES / "retired-req-tested") == 0
+
+
+def test_empty_dhf(tmp_path):
+    """An empty DHF directory (no YAML files) should pass."""
+    (tmp_path / "requirements").mkdir()
+    (tmp_path / "risk").mkdir()
+    (tmp_path / "verification").mkdir()
+    assert check(tmp_path) == 0
+
+
+def test_draft_requirements_not_required_to_be_tested(tmp_path):
+    (tmp_path / "requirements").mkdir()
+    (tmp_path / "risk").mkdir()
+    (tmp_path / "verification").mkdir()
+    (tmp_path / "requirements" / "reqs.yaml").write_text(
+        "version: '1.0'\nrequirements:\n  - id: SW-001\n    title: Draft req\n    status: draft\n"
+    )
+    (tmp_path / "risk" / "hazards.yaml").write_text("version: '1.0'\nhazards: []\n")
+    (tmp_path / "verification" / "tests.yaml").write_text("version: '1.0'\ntests: []\n")
+    assert check(tmp_path) == 0
+
+
+def test_retired_requirements_not_required_to_be_tested(tmp_path):
+    (tmp_path / "requirements").mkdir()
+    (tmp_path / "risk").mkdir()
+    (tmp_path / "verification").mkdir()
+    (tmp_path / "requirements" / "reqs.yaml").write_text(
+        "version: '1.0'\nrequirements:\n  - id: SW-001\n    title: Retired req\n    status: retired\n"
+    )
+    (tmp_path / "risk" / "hazards.yaml").write_text("version: '1.0'\nhazards: []\n")
+    (tmp_path / "verification" / "tests.yaml").write_text("version: '1.0'\ntests: []\n")
+    assert check(tmp_path) == 0
+
+
+def test_serious_hazard_without_controls_fails(tmp_path):
+    (tmp_path / "requirements").mkdir()
+    (tmp_path / "risk").mkdir()
+    (tmp_path / "verification").mkdir()
+    (tmp_path / "requirements" / "reqs.yaml").write_text("version: '1.0'\nrequirements: []\n")
+    (tmp_path / "risk" / "hazards.yaml").write_text(
+        "version: '1.0'\nhazards:\n"
+        "  - id: HZ-001\n    title: Serious uncontrolled\n"
+        "    severity: serious\n    probability: probable\n    risk_level: unacceptable\n"
+        "    controls: []\n    severity_residual: serious\n"
+    )
+    (tmp_path / "verification" / "tests.yaml").write_text("version: '1.0'\ntests: []\n")
+    assert check(tmp_path) == 1
+
+
+def test_negligible_hazard_without_controls_passes(tmp_path):
+    (tmp_path / "requirements").mkdir()
+    (tmp_path / "risk").mkdir()
+    (tmp_path / "verification").mkdir()
+    (tmp_path / "requirements" / "reqs.yaml").write_text("version: '1.0'\nrequirements: []\n")
+    (tmp_path / "risk" / "hazards.yaml").write_text(
+        "version: '1.0'\nhazards:\n"
+        "  - id: HZ-001\n    title: Negligible hazard\n"
+        "    severity: negligible\n    probability: incredible\n    risk_level: acceptable\n"
+        "    controls: []\n"
+    )
+    (tmp_path / "verification" / "tests.yaml").write_text("version: '1.0'\ntests: []\n")
+    assert check(tmp_path) == 0


### PR DESCRIPTION
## Summary

Closes #24.

Delivers the full IEC 62304 §5 traceability pipeline: JSON schemas for DHF YAML files, Python scripts to build the traceability matrix and detect coverage gaps, a reusable workflow callable from any clinical repo, a DHF template scaffold, 19 unit tests, and a complete governance guide.

- **`reusable-iec62304-traceability.yml`** — complete rewrite using the new scripts; inputs: `dhf-path`, `version`, `fail-on-gap`, `skip`; SHA-pinned actions; posts PR comment with gap count and report; uploads HTML + JSON matrix as 90-day artifact
- **`scripts/traceability/build_matrix.py`** — parses all `dhf/**/*.yaml` files (validated against JSON schemas), builds `traceability-matrix.json` and `traceability-matrix.html`; sortable HTML table with pass/fail coloring
- **`scripts/traceability/check_gaps.py`** — four hard rules (missing test, serious hazard without control, orphan RC, duplicate IDs) + one warning (active test on retired req); exits 0/1/2
- **`policies/dhf/schemas/`** — three JSON Schema files validated by `build_matrix.py` and usable by the YAML Language Server for IDE autocomplete
- **`templates/dhf/`** — annotated DHF scaffold (requirements, risk, verification, `classification.md`, `README.md`) for bootstrapping new clinical repos
- **`tests/traceability/`** — 19 unit tests across 5 fixture sets
- **`docs/compliance/dhf-guide.md`** — complete user guide (classification, quick start, ID conventions, writing good requirements, risk analysis, test mapping, common pitfalls, CI integration)

## Acceptance criteria

- [x] `reusable-iec62304-traceability.yml` callable from any clinical repo
- [x] `build_matrix.py` parses `dhf/**/*.yaml` and emits `traceability-matrix.json` and `.html`
- [x] `check_gaps.py` exits 0 only if every SW-### has ≥1 test and every HZ-### with serious+ severity has ≥1 RC-###
- [x] DHF skeleton under `templates/dhf/` copyable into new clinical repos
- [x] Schemas validated: `requirements.schema.json`, `hazard-analysis.schema.json`, `unit-test-map.schema.json`
- [x] `docs/compliance/dhf-guide.md` explains the full flow
- [ ] Sample repo demonstration (deferred — requires a separate class-b repo)

## Tests

```
54 passed in 0.44s  (35 chain + 19 traceability)
```

Traceability test coverage:
- `valid-minimal` fixture: 2 reqs, 1 hazard, 1 RC, all tested → **pass**
- `missing-test` fixture: SW-002 has no test → **fail at SW-002**
- `orphan-rc` fixture: RC-001 cited by hazard but not by any req → **fail**
- `duplicate-id` fixture: two SW-001 entries → **fail with location**
- `retired-req-tested` fixture: test cites retired req → **warn, exit 0**

## Usage in a clinical repo

```yaml
# .github/workflows/ci.yml
traceability:
  uses: ruralpeds/.github/.github/workflows/reusable-iec62304-traceability.yml@main
  with:
    dhf-path: dhf
    fail-on-gap: true
  permissions:
    contents: read
    pull-requests: write
```

https://claude.ai/code/session_012afAvvFyUPjKwx4nJkhjUf

---
_Generated by [Claude Code](https://claude.ai/code/session_012afAvvFyUPjKwx4nJkhjUf)_