### PR TITLE
feat(rulesets): add qa-develop-protection + fix org-name in sync work…

### DIFF
--- a/.github/workflows/sync-rulesets.yml
+++ b/.github/workflows/sync-rulesets.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           app-id: ${{ vars.TH_BOT_APP_ID }}
           private-key: ${{ secrets.TH_BOT_PRIVATE_KEY }}
-          owner: timothyhartzog
+          owner: ${{ github.repository_owner }}
 
       # ── 2. Choose token (App token preferred, fallback to PAT) ─────────────
       - name: Resolve token
@@ -102,9 +102,9 @@ jobs:
           if [ -n "${{ inputs.target-repos }}" ]; then
             echo "${{ inputs.target-repos }}" | tr ',' '\n' | tr -d ' ' > repos.txt
           else
-            gh api --paginate "/orgs/timothyhartzog/repos?per_page=100" \
+            gh api --paginate "/orgs/${{ github.repository_owner }}/repos?per_page=100" \
               --jq '.[] | select(.archived == false and .fork == false) | .name' > repos.txt \
-            || gh api --paginate "/users/timothyhartzog/repos?per_page=100" \
+            || gh api --paginate "/users/${{ github.repository_owner }}/repos?per_page=100" \
               --jq '.[] | select(.archived == false and .fork == false) | .name' > repos.txt
           fi
           echo "Target repo count: $(wc -l < repos.txt)"
@@ -139,17 +139,17 @@ jobs:
               echo "→ $repo"
 
               # Check if the ruleset already exists by name
-              EXISTING=$(gh api "/repos/timothyhartzog/$repo/rulesets" --jq \
+              EXISTING=$(gh api "/repos/${{ github.repository_owner }}/$repo/rulesets" --jq \
                 ".[] | select(.name == \"$RULESET_NAME\") | .id" 2>/dev/null || echo "")
 
               if [ -n "$EXISTING" ]; then
                 ACTION="update"
                 METHOD="PUT"
-                ENDPOINT="/repos/timothyhartzog/$repo/rulesets/$EXISTING"
+                ENDPOINT="/repos/${{ github.repository_owner }}/$repo/rulesets/$EXISTING"
               else
                 ACTION="create"
                 METHOD="POST"
-                ENDPOINT="/repos/timothyhartzog/$repo/rulesets"
+                ENDPOINT="/repos/${{ github.repository_owner }}/$repo/rulesets"
               fi
 
               if [ "$DRY_RUN" = "true" ]; then

--- a/policies/rulesets/README.md
+++ b/policies/rulesets/README.md
@@ -1,0 +1,35 @@
+# Org-level rulesets (`policies/rulesets/`)
+
+These JSON files define [GitHub Repository Rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) at the **organization level**. The `sync-rulesets.yml` workflow applies every `*.json` file here to every non-archived, non-fork repo in the org.
+
+## Files
+
+| File | Targets | Purpose |
+|------|---------|---------|
+| `org-baseline.json` | All repos | Baseline security: signed commits, ≥1 reviewer, no force-push to default |
+| `signed-commits-main.json` | `main`, `master`, `release/*` | Strictest: signed commits, linear history, dismiss stale reviews, require last-push approval, PHI-scan required check |
+| `qa-develop-protection.json` | `qa`, `develop` | Pre-production branch protection: PR + 1 review + linear history + no force-push + no deletion. Signed commits NOT required (those are reserved for `main`). |
+| `org-clinical.json` | Property: `criticality ∈ {clinical-support, clinical-decision, device}` | 2 reviewers, signed commits, required CI/PHI/SBOM/CodeQL/Scorecard checks |
+| `org-device.json` | Property: `iec62304-class ∈ {class-b, class-c}` | Stricter still — IEC 62304 traceability, hazard-analysis update enforcement |
+| `org-fda-part11.json` | Property: `data-classification = phi-active` or regulated | Part 11 e-signatures, deployment approval gates |
+| `org-phi-active.json` | Property: `data-classification = phi-active` | PHI-specific controls; environment manual approval |
+
+## Three-branch flow
+
+The `signed-commits-main.json` + `qa-develop-protection.json` pair together enforce the three-branch promotion model: `develop → qa → main`. See per-repo `docs/BRANCHING_MODEL.md` for the day-to-day workflow.
+
+## How to apply
+
+Changes to any file here trigger `.github/workflows/sync-rulesets.yml` on push to `main`. To apply manually:
+
+1. **Actions tab** → **Sync Rulesets (Governance as Code)** → **Run workflow**
+2. Optionally pick `dry-run: true` first to preview
+3. Optionally specify `target-repos` (comma-separated) to limit scope
+
+## Adding a new ruleset
+
+1. Drop a `*.json` file in this directory following GitHub's [ruleset schema](https://docs.github.com/en/rest/repos/rules)
+2. Set `enforcement: "evaluate"` initially to monitor without blocking
+3. Open a PR; CI validates JSON shape
+4. After merge, `sync-rulesets.yml` propagates it
+5. Once you've verified no false positives, flip to `enforcement: "active"` in a follow-up PR

--- a/policies/rulesets/qa-develop-protection.json
+++ b/policies/rulesets/qa-develop-protection.json
@@ -1,0 +1,44 @@
+{
+  "name": "qa-develop-protection",
+  "description": "Protects pre-production branches (qa, develop) across all org repos. Requires PR review, prevents force-push and deletion, enforces linear history. Does NOT require signed commits (those are enforced separately on main via medical-software-main-protection).",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/qa",
+        "refs/heads/develop"
+      ],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "automatic_copilot_code_review_enabled": false
+      }
+    }
+  ],
+  "metadata": {
+    "applies_to": "Pre-production branches (qa, develop) on all repositories that have these branches. Repositories without these branches are unaffected.",
+    "min_reviewers": 1,
+    "requires_signatures": false,
+    "comment": "Companion to medical-software-main-protection (which covers main/master/release/*). Together these enforce the three-branch promotion flow (develop -> qa -> main). Signed commits are not required on qa/develop because they may receive cherry-picks and routine integration work where the signing barrier creates friction; signed commits remain enforced on main."
+  }
+}


### PR DESCRIPTION
…flow

Adds an organization-level ruleset that protects the qa and develop branches across every repo in the org. Required for the three-branch flow (develop -> qa -> main) introduced on ruralpeds/peds and ruralpeds/rust-sci-core.

Rules applied to refs/heads/qa and refs/heads/develop:
- deletion blocked
- non_fast_forward (no force push that drops commits)
- required_linear_history (squash or rebase merges only)
- pull_request: 1 reviewer, dismiss stale reviews on push, required review thread resolution

Signed commits intentionally NOT required on qa/develop (reserved for main via the existing medical-software-main-protection ruleset) so that integration cherry-picks and routine work do not fail when contributors do not have GPG/SSH signing configured.

Also patches sync-rulesets.yml to derive the org name from ${{ github.repository_owner }} instead of the hardcoded 'timothyhartzog' literal. This makes the workflow correct regardless of which org/account hosts the .github repo (it currently lives at ruralpeds/.github, so the previous hardcoded value was incorrect).

Adds policies/rulesets/README.md documenting the full ruleset suite and the three-branch flow tie-in.