### PR TITLE
feat: add sprint-standard v1

### DIFF
--- a/docs/PLAN_AUTHORING_RUBRIC.md
+++ b/docs/PLAN_AUTHORING_RUBRIC.md
@@ -1,0 +1,121 @@
+# Build Plan Authoring Rubric
+
+> **Audience**: Claude (or a human author working with Claude) producing a build plan that will be converted into Copilot agent sprints.
+> **Tooling**: `scripts/plan_to_tasks.py` consumes plans authored to this rubric.
+
+A plan that follows this rubric converts cleanly into `copilot-tasks/*.md` files with no manual fix-ups. Plans that don't are still readable, but the converter will either complain or produce coarser task files that need editing.
+
+## Required structure
+
+```markdown
+# <Project> — Comprehensive Build Plan
+
+**Repo:** owner/repo
+**Target:** ...
+**Stack:** ...
+**Buildable by:** Claude Haiku 4.5 in agentic mode, or GitHub Copilot Workspace / Copilot Agent
+
+## 0. Why this design               (free prose, optional)
+
+## 1. Repository layout             (REQUIRED — fenced code block with file tree)
+
+## 2. ... up to ## N-2.             (architecture, design decisions, free prose)
+
+## N-2. Phased build (REQUIRED)
+
+### Phase 0 — Bootstrap
+1. Step one.
+2. Step two.
+
+Done check: <one-line testable condition>
+
+### Phase 1 — <name>
+1. Step one.
+
+Done check: <...>
+Depends on: Phase 0 merged.
+
+### Phase 6 — Replicate per calculator
+Fan out across: finance, strategy, operations, risk
+
+1. For each item, do X.
+
+Done check: <...>
+Depends on: Phase 5 merged.
+
+## N-1. Agent execution prompts     (optional)
+
+## N. Acceptance criteria           (REQUIRED — full-build done check)
+```
+
+## Required per-phase rules
+
+| Element | Required? | Notes |
+|---|---|---|
+| `### Phase NN — <name>` | yes | NN is sequential, zero-padded by the converter. |
+| Numbered step list | yes | Becomes the `## Approach` body section. |
+| `Done check:` line | yes | Becomes `acceptance-criteria:` (one entry). |
+| `Depends on:` line | when not phase 0 | "Phase N merged" → resolved to slug. |
+| `Fan out across: <a, b, c>` line | when fanning out | Produces one task per item. |
+
+## Conventions that produce cleaner output
+
+1. **Short phase names.** They become slugs and filenames; under 30 chars is best. Use specific verbs ("WASM facade expansion", not "Foundation"). The converter truncates anything longer.
+2. **One Done check per phase.** If you find yourself listing two, that's two phases.
+3. **Explicit fan-out marker.** "Parallelizable" in prose works as a fallback, but the explicit `Fan out across: a, b, c` line is unambiguous and machine-readable.
+4. **Hard rules in section 0.** A `### Hard rules` subsection in the early "Why this design" or "Architecture" sections gets propagated into the `## Context` section of every task file. Use it for things that apply globally (no Tailwind 4, no Next.js, USA-only citations, etc.).
+5. **Don't put steps inside Markdown sub-bullets.** Top-level numbered list only. Nested bullets become commentary, not steps.
+
+## Anti-patterns
+
+- **Run-on phases.** A phase that takes more than a day to author tasks for is too big. Split it.
+- **Vague Done checks.** "It works" is not a Done check. "`cargo test --workspace` passes" is.
+- **Cross-phase coupling without explicit `Depends on:`.** The converter assumes phases are independent unless told otherwise.
+- **Implicit fan-out.** Saying "this should be parallelized" without the marker line means it won't be. Be explicit.
+
+## Example: a minimal valid plan
+
+```markdown
+# Tiny Calculator — Build Plan
+
+## 1. Repository layout
+
+```
+calc/
+├── src/main.rs
+└── tests/
+```
+
+## 11. Phased build
+
+### Phase 0 — Scaffold
+
+1. `cargo new calc`.
+2. Add a `tests/` directory with one passing test.
+
+Done check: `cargo test` passes.
+
+### Phase 1 — Add divide function
+
+1. Implement `pub fn divide(a: f64, b: f64) -> Result<f64, String>`.
+2. Test divide-by-zero returns Err.
+
+Done check: `cargo test` passes including the new test.
+Depends on: Phase 0 merged.
+
+## 12. Acceptance criteria
+
+`cargo test` and `cargo clippy -- -D warnings` both pass.
+```
+
+That plan parses cleanly and produces two task files.
+
+## How the rubric is enforced
+
+The converter (`plan_to_tasks.py`) is fail-loud:
+
+- Missing `## Phased build` section → error.
+- Phase missing `Done check:` → error.
+- Phase header that doesn't match `### Phase NN — <name>` → silently skipped (so you can have non-phase subsections in the build section).
+
+If the converter complains, fix the plan, not the converter.

--- a/docs/SPRINT_STANDARD.md
+++ b/docs/SPRINT_STANDARD.md
@@ -1,0 +1,277 @@
+# Sprint Standard for Claude → Copilot Agent Workflows
+
+> **Last Updated**: 2026-04-29
+> **Governance Level**: Recommended for all `ruralpeds/*` repos
+> **Status**: v1.0
+> **Builds on**: `AGENTS.md` (universal agent contract), `copilot-tasks/_schema.md` (task file format), `seed_issues.py` (issue seeder)
+
+## What this document is
+
+A **repeatable pattern** for turning a Claude-authored build plan into a sequence of GitHub Copilot agent sprints, executed inside a reproducible VS Code + Docker devcontainer environment.
+
+The pattern has three layers, each addressed by a separate document or directory in this organization repo:
+
+| Layer | Artifact | Purpose |
+|---|---|---|
+| **Plan** | `<REPO>_BUILD_PLAN.md` (committed to the target repo's root) | Single Claude-authored markdown file describing the full multi-sprint build, with explicit phases and acceptance checks. |
+| **Sprints** | `copilot-tasks/phase-NN-*/task-*.md` files (committed to the target repo) | Machine-readable task files generated from the plan, one per executable unit, conforming to `_schema.md`. |
+| **Runtime** | `.devcontainer/devcontainer.json` (committed to the target repo) | VS Code dev container so every sprint runs in identical Docker-based tooling whether driven by a human, the cloud agent, or VS Code agent mode. |
+
+Three commands take a freshly Claude-authored plan to a running fleet of agent sprints:
+
+```bash
+ruralpeds-sprint init <repo>            # add devcontainer + plan scaffolding
+ruralpeds-sprint plan-to-tasks <plan>   # convert plan markdown → copilot-tasks/*.md
+ruralpeds-sprint kickoff <repo>         # seed issues + assign @copilot
+```
+
+Those three commands are the thin wrapper this standard adds on top of existing org tooling. The rest is policy.
+
+## Why this exists
+
+The org already has excellent infrastructure for individual Copilot tasks (the `copilot-tasks/` schema, `seed_issues.py`, the guardrail workflow). What was missing was an **end-to-end sprint pattern** that connects three things which had been informal:
+
+1. **How a Claude-generated build plan becomes a series of sprints.** Previously: a person hand-translated a plan into task files. Now: deterministic, with a converter that enforces the schema.
+2. **How sprints run in VS Code.** Previously: each developer's IDE setup was their own. Now: a versioned devcontainer pinned to specific tool versions so VS Code Copilot agent mode and the cloud agent see the same environment.
+3. **How sprint dependencies are encoded so agents don't start prematurely.** Previously: prose hints in issue bodies. Now: the existing `depends-on:` frontmatter field enforced by the seeder, plus a phase-locking gate in the guardrails workflow.
+
+This standard is **additive**. It does not replace `AGENTS.md`, the gap analysis lifecycle, or the existing copilot-tasks schema. It composes them into a sprint loop.
+
+## The sprint loop
+
+```
+        ┌─────────────────────────────────┐
+        │  1. Author build plan           │
+        │     (Claude, in this app)       │
+        │     → <REPO>_BUILD_PLAN.md      │
+        └──────────────┬──────────────────┘
+                       │
+                       ▼
+        ┌─────────────────────────────────┐
+        │  2. Plan → tasks                │
+        │     ruralpeds-sprint            │
+        │       plan-to-tasks <plan>      │
+        │     → copilot-tasks/*.md        │
+        └──────────────┬──────────────────┘
+                       │
+                       ▼
+        ┌─────────────────────────────────┐
+        │  3. Commit plan + tasks +       │
+        │     devcontainer to main        │
+        └──────────────┬──────────────────┘
+                       │
+                       ▼
+        ┌─────────────────────────────────┐
+        │  4. Kickoff                     │
+        │     ruralpeds-sprint kickoff    │
+        │     → seed_issues.py runs       │
+        │     → issues assigned @copilot  │
+        └──────────────┬──────────────────┘
+                       │
+                       ▼
+   ┌───────────────────┴───────────────────┐
+   │                                       │
+   ▼                                       ▼
+┌──────────────────────┐   ┌──────────────────────────────┐
+│ Cloud agent (PR per  │   │ VS Code agent mode (devcon-  │
+│ issue, GitHub-hosted │   │ tainer; same Docker runtime  │
+│ Actions runner)      │   │ as cloud agent)              │
+└──────────┬───────────┘   └──────────┬───────────────────┘
+           │                          │
+           └──────────────┬───────────┘
+                          ▼
+        ┌─────────────────────────────────┐
+        │  5. Human review per PR         │
+        │     guardrails workflow gates   │
+        │     merge                       │
+        └──────────────┬──────────────────┘
+                       │
+                       ▼
+        ┌─────────────────────────────────┐
+        │  6. Sprint retro                │
+        │     update plan + close phase   │
+        │     gap-analysis lifecycle      │
+        └─────────────────────────────────┘
+```
+
+Steps 1-3 are author-side. Step 4 is one command. Steps 5-6 are review and retro.
+
+## Sprint definition (what is a "sprint" in this standard)
+
+A **sprint** is the agent-execution of one phase of the build plan. A phase is a numbered section of the plan that has its own acceptance check and that the plan's author has marked as a sprint boundary. Concretely:
+
+- A sprint maps to one `copilot-tasks/phase-NN-<slug>/` directory.
+- A sprint contains one or more task files (typically 1-15).
+- A sprint has at most one parallelizable batch (the "fan-out" — see §6).
+- A sprint completes when all its tasks' PRs are merged AND the phase's acceptance check passes.
+
+This is the same definition used informally in the `copilot-tasks/phase-01-platform-hardening/` etc. directories, just made explicit.
+
+## Build plan requirements
+
+Any markdown file authored as a Claude build plan and intended to feed this pipeline must have the following structure. The `plan-to-tasks` converter is fail-loud: missing sections cause the conversion to abort with a precise error.
+
+### Required sections, in order
+
+```
+# <title>
+
+## 0. Why this design          (free prose, recommended)
+## 1. Repository layout         (file tree as fenced ``` block)
+## 2. <Architecture sections>   (any number, free prose)
+...
+## N-2. Phased build            (REQUIRED — must contain "### Phase 0", "### Phase 1", ...)
+## N-1. Agent execution prompts (OPTIONAL — used as fallback task body if a phase has no body)
+## N.   Acceptance criteria     (REQUIRED — converted to a final sprint that runs the smoke checks)
+```
+
+### Required per-phase content
+
+Inside the "Phased build" section, every `### Phase NN — <name>` heading must contain:
+
+- **A numbered list of steps** (becomes the task body's `## Approach` section).
+- **A "Done check:"** line at the end (becomes the `acceptance-criteria:` frontmatter).
+- **Optionally** a "Depends on:" line ("Phase N-1 merged") that becomes `depends-on:`.
+- **Optionally** a "Parallelizable across <list>" line — the converter will fan that phase out into one task per item.
+
+### Example
+
+The plan format we used for `hospital-economics-rust` (`HFE_UI_BUILD_PLAN.md`) is the canonical reference. New plans should clone its structure.
+
+## Task file mapping
+
+The converter applies this mapping from plan markdown to `copilot-tasks/` task files:
+
+| Plan element | Task frontmatter field |
+|---|---|
+| `### Phase NN — <name>` heading text | `title:` |
+| Phase number `NN` (zero-padded) | `phase: phase-NN` |
+| Slug from heading | `slug:` |
+| Numbered list under heading | Body `## Approach` section |
+| `Done check: <text>` | `acceptance-criteria:` (one item) |
+| `Depends on: <text>` | `depends-on:` |
+| Plan's `## 1. Repository layout` files mentioned in the phase | `files-to-touch:` (best-effort glob extraction) |
+| Plan's hard rules in `### Hard rules` (if present) | Body `## Context` section |
+| Plan-level standards (CMS FY2026, IEC 62304, etc.) | `standards:` |
+| `Parallelizable across <a, b, c>` | One task file per item; suffix `-<item>` on slug |
+| Default | `preferred-agent: copilot`, `requires-human-after: review`, `estimated-complexity: m` |
+
+The converter is **deterministic and idempotent** — running it twice on the same plan produces the same task files (modulo whitespace). Already-existing task files are diffed and overwritten only if the phase content has changed; manual edits to a task file are detected via a `# converter-managed: false` comment that pins it.
+
+## Devcontainer runtime
+
+The runtime layer is a single `.devcontainer/devcontainer.json` file plus a `Dockerfile` derived from a base image this org maintains. It is committed to the target repo, not to `ruralpeds/.github`, so each repo can pin language-specific tool versions while inheriting the org base.
+
+### Goals
+
+1. **Identical environment** for VS Code agent mode, the cloud agent (which runs in GitHub Actions), and a human contributor on a fresh checkout.
+2. **No secrets baked in.** The container assumes a GitHub PAT is supplied via the IDE's GitHub auth or, in CI, via the workflow's `GITHUB_TOKEN`.
+3. **Pre-warmed toolchains.** Rust, Node, Python, Julia, and `wasm-pack` ready on first open. Cold start of a sprint should not require any installs.
+4. **Reproducible by SHA.** Base image pinned by digest, language toolchains pinned by exact version.
+
+### Base image
+
+The org provides a base image at `ghcr.io/ruralpeds/sprint-base:<tag>` containing:
+
+- Ubuntu 24.04 (matches GitHub Actions `ubuntu-latest`)
+- Rust stable + `wasm-pack` + `wasm32-unknown-unknown` target
+- Node 22 LTS + `pnpm` + `npm`
+- Python 3.12 + `uv` + `pipx`
+- Julia 1.11
+- `gh` CLI, `act` (for local workflow runs), `pre-commit`
+- VS Code `code-server` extensions auto-installed: GitHub Copilot, GitHub Pull Requests, Rust Analyzer, Tauri, ESLint, Prettier, Julia, Python, Pylance
+
+Repos extend this image only when they need something out-of-band (e.g., heavy ML deps). 90% of repos use the base directly.
+
+### Required `devcontainer.json` fields
+
+The template at `templates/sprint-bundle/.devcontainer/devcontainer.json` enforces the minimum. The required fields are:
+
+- `image` pinned to a digest, not a tag
+- `features` list pinned by version
+- `customizations.vscode.extensions` list (Copilot, Pull Requests, language-specific)
+- `postCreateCommand` set to `./scripts/devcontainer-postcreate.sh` (a repo-local script)
+- `remoteUser` set to `vscode` (never `root`)
+- `mounts` for the GitHub auth socket so `gh` works without re-auth
+
+## Cloud agent vs VS Code agent mode
+
+Both consume the same task files; the difference is where they run.
+
+| Aspect | Cloud agent (`@copilot` on issue) | VS Code agent mode (chat in IDE) |
+|---|---|---|
+| Trigger | Issue assignment | Chat command |
+| Runtime | GitHub Actions ephemeral runner | Local devcontainer |
+| Speed | Slower (cold start), unattended | Faster, interactive |
+| Best for | Sequential phases (0-5), parallel fan-out (phase 6) | Tricky single tasks, debug after a failed cloud-agent PR |
+| Network | Restricted by org allowlist | Same allowlist policy enforced via firewall in devcontainer |
+| Secrets | Workflow secrets only | User's gh auth token only |
+
+Recommended pattern: **cloud agent does the bulk; VS Code agent mode is the rescue lever** when a cloud-agent PR drifts and a comment-driven iteration isn't converging.
+
+## Phase locking
+
+To prevent the cloud agent from starting Phase 1 before Phase 0 is merged, this standard relies on the existing `copilot-task-guardrails.yml` workflow plus one new convention:
+
+1. The `depends-on:` frontmatter field on a task lists task slugs that must be merged first.
+2. The seeder script reads `depends-on:` and labels the issue `blocked:awaiting-<slug>` if any dependency is not yet merged.
+3. The cloud agent is configured (in `.github/copilot-instructions.md` of the target repo) to refuse to start work on issues with a `blocked:*` label.
+4. When the depended-upon PR merges, a workflow strips the `blocked:awaiting-<slug>` label from any issue depending on it; if no `blocked:*` labels remain, the issue is free for the agent.
+
+This is a soft lock — humans can override it by removing the label manually. It exists to catch the common case where someone runs the kickoff script and 9 sprints fire simultaneously.
+
+## Parallel fan-out
+
+Phases marked `Parallelizable across <list>` produce one task per list item. They share `phase: phase-NN` but have distinct slugs. They each `depends-on:` the previous sequential phase. They do **not** depend on each other, so they all unblock simultaneously when the previous phase merges. This is how the 7 domains of Phase 6 in the HFE plan run in parallel.
+
+The cap is **8 simultaneous agent sessions per repo**. The seeder enforces this by labeling tasks beyond the 8th with `queued:phase-NN` and the unblocking workflow promotes them to active as earlier ones merge.
+
+## Branch naming
+
+Conforms to the existing `AGENTS.md` §3 rule:
+
+```
+agent/<phase>/<slug>-<short-issue-#>
+```
+
+Example: `agent/phase-06/finance-127`. The cloud agent generates this automatically; VS Code agent mode is reminded by the devcontainer's `postCreateCommand` which prints the convention on shell open.
+
+## PR review and merge
+
+The standard does not change the PR review rules in `AGENTS.md` §3. It only adds two recommendations:
+
+- **Always click "Approve and run workflows" the first time.** Cloud-agent PRs require explicit approval before CI runs.
+- **Use the sprint retro template** at `docs/SPRINT_RETRO_TEMPLATE.md` after each phase merges, even if the retro is just one sentence ("clean run, no notes").
+
+## Sprint retro
+
+After a phase merges, the author creates a brief retro in the target repo at `docs/sprint-retros/phase-NN-<slug>.md`. The template is short on purpose. Its only required fields:
+
+- What went well
+- What needed re-prompting (and the prompt that fixed it)
+- What you would change in the plan if you authored it again
+- Whether to keep the same phase boundaries next time
+
+The retros feed back into improving the **plan-authoring rubric** that Claude uses for the next plan. We collect them at the org level under `docs/sprint-retros-corpus/` once a quarter for prompt refinement.
+
+## Adoption
+
+A repo adopts this standard by running:
+
+```bash
+gh repo clone ruralpeds/.github /tmp/ruralpeds-github
+/tmp/ruralpeds-github/scripts/sprint-init.sh <my-repo-path>
+```
+
+Which copies `templates/sprint-bundle/` into the repo, validates that `AGENTS.md` is referenced, and opens a PR titled `chore: adopt sprint-standard v1`.
+
+## Versioning
+
+This standard is versioned. v1.0 is the initial release. Backwards-incompatible changes (e.g., the converter's frontmatter mapping) require a major bump and an `UPGRADE.md` entry.
+
+## See also
+
+- `AGENTS.md` — universal agent contract (precedence over this document on safety items).
+- `copilot-tasks/_schema.md` — canonical task file schema.
+- `docs/CLAUDE_CODE_GAP_PROTOCOL.md` — gap-analysis lifecycle, complementary to sprints.
+- `docs/AGENT_WORKFLOW.md` — broader agent workflow that this sprint pattern fits into.

--- a/scripts/plan_to_tasks.py
+++ b/scripts/plan_to_tasks.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""plan_to_tasks.py — Convert a Claude-authored build plan into copilot-tasks/*.md files.
+
+The plan must follow the structure documented in docs/SPRINT_STANDARD.md §"Build plan
+requirements". This script:
+
+  1. Parses the plan markdown.
+  2. Locates the "Phased build" section and walks each "### Phase NN — <name>" subsection.
+  3. For each phase, extracts: the numbered step list, the "Done check:" line, the optional
+     "Depends on:" line, and the optional "Parallelizable across <a, b, c>" line.
+  4. Emits one task file per phase (or per fan-out item) into <repo>/copilot-tasks/phase-NN-<slug>/
+     conforming to copilot-tasks/_schema.md.
+  5. Idempotent: existing files with body comment `# converter-managed: false` are skipped.
+     All other existing files are diffed and overwritten only if content has changed.
+
+Usage:
+    python plan_to_tasks.py --plan PATH --target-repo PATH [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class Phase:
+    number: str  # "00", "01", ...
+    name: str  # "Bootstrap"
+    slug: str  # "bootstrap"
+    steps: list[str] = field(default_factory=list)
+    done_check: str = ""
+    depends_on: list[str] = field(default_factory=list)
+    parallel_items: list[str] = field(default_factory=list)
+    raw_body: str = ""
+
+
+PHASE_HEADER_RE = re.compile(r"^### Phase (\d+)\s*[—\-:]\s*(.+?)\s*$", re.MULTILINE)
+DONE_CHECK_RE = re.compile(
+    r"(?:^|\n)\s*(?:[-*]\s*)?\*{0,2}Done check:?\*{0,2}\s*(.+?)(?:\n|$)",
+    re.IGNORECASE,
+)
+DEPENDS_ON_RE = re.compile(r"Depends on:\s*(.+?)(?:\n|$)", re.IGNORECASE)
+PARALLEL_RE = re.compile(
+    r"[Pp]arallelizable[^\n]*?(?:across|over|by)\s+(?:the\s+)?(?:\d+\s+)?(?:agents?|domains?|items?)?[,:]?\s*(?:one per\s+)?([a-z][\w\s,/-]*?)(?:\n|\.|$)",
+    re.IGNORECASE,
+)
+PARALLEL_LIST_RE = re.compile(
+    r"^Parallel(?:izable)? (?:across|over|by) (?:the (?:following|seven|eight|nine|ten))?[:\s]+(.+?)$",
+    re.IGNORECASE | re.MULTILINE,
+)
+NUMBERED_STEP_RE = re.compile(r"^\s*(\d+)\.\s+(.+?)$", re.MULTILINE)
+
+
+def slugify(name: str) -> str:
+    """Convert a phase name to a kebab-case slug, capped at ~30 chars."""
+    s = name.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = s.strip("-")
+    # Truncate after a reasonable length, ending on a word boundary.
+    if len(s) > 30:
+        cut = s[:30].rsplit("-", 1)[0]
+        s = cut if cut else s[:30]
+    return s
+
+
+def find_phased_build_section(text: str) -> str:
+    """Locate the section containing the Phased build content.
+
+    We accept any heading whose text contains 'Phased build' or 'Phases' as the marker.
+    Returns the text from that heading to the next ## heading.
+    """
+    pattern = re.compile(
+        r"^##\s+\d+\.\s+(?:Phased\s+build|Phases?).*?$",
+        re.MULTILINE | re.IGNORECASE,
+    )
+    m = pattern.search(text)
+    if not m:
+        raise ValueError(
+            "Plan is missing a '## N. Phased build' section (required). "
+            "See docs/SPRINT_STANDARD.md §'Build plan requirements'."
+        )
+    start = m.start()
+    next_h2 = re.search(r"^##\s+\d+\.\s+", text[m.end() :], re.MULTILINE)
+    end = m.end() + (next_h2.start() if next_h2 else len(text) - m.end())
+    return text[start:end]
+
+
+def parse_phase_block(num: str, name: str, body: str) -> Phase:
+    slug = slugify(name)
+
+    # Done check
+    dc = DONE_CHECK_RE.search(body)
+    done_check = dc.group(1).strip() if dc else ""
+    if not done_check:
+        raise ValueError(
+            f"Phase {num} ({name}) is missing a 'Done check:' line. "
+            "Every phase must declare a testable done condition."
+        )
+
+    # Depends on
+    depends_on: list[str] = []
+    do = DEPENDS_ON_RE.search(body)
+    if do:
+        # "Phase 0 merged" -> phase number; we'll resolve to slugs in the linker step.
+        m = re.search(r"phase\s*(\d+)", do.group(1), re.IGNORECASE)
+        if m:
+            depends_on = [f"PHASE-{int(m.group(1)):02d}"]
+
+    # Parallel fan-out — three detection strategies, in order of preference:
+    # 1. Explicit marker line: `Fan out across: a, b, c`
+    # 2. Prose: "Parallelizable across <list>"
+    # 3. Loop in kickoff prose: "for X in a b c d"
+    parallel_items: list[str] = []
+    fan_out_re = re.compile(r"^Fan[- ]out across:\s*(.+?)$", re.IGNORECASE | re.MULTILINE)
+    fo = fan_out_re.search(body)
+    if fo:
+        parallel_items = [s.strip() for s in re.split(r"[,;]| and ", fo.group(1)) if s.strip()]
+    else:
+        pl = PARALLEL_LIST_RE.search(body)
+        if pl:
+            parallel_items = [s.strip() for s in re.split(r"[,;]| and ", pl.group(1)) if s.strip()]
+        else:
+            # Fall back to detecting bash for-loops in the body.
+            loop_re = re.compile(r"for\s+\w+\s+in\s+([a-z][\w\s-]+?);\s*do", re.IGNORECASE)
+            lo = loop_re.search(body)
+            if lo:
+                parallel_items = [s.strip() for s in lo.group(1).split() if s.strip()]
+
+    # Numbered steps
+    steps = [m.group(2).strip() for m in NUMBERED_STEP_RE.finditer(body)]
+
+    return Phase(
+        number=num.zfill(2),
+        name=name,
+        slug=slug,
+        steps=steps,
+        done_check=done_check,
+        depends_on=depends_on,
+        parallel_items=parallel_items,
+        raw_body=body.strip(),
+    )
+
+
+def parse_phases(text: str) -> list[Phase]:
+    section = find_phased_build_section(text)
+    phases: list[Phase] = []
+    headers = list(PHASE_HEADER_RE.finditer(section))
+    for i, h in enumerate(headers):
+        start = h.end()
+        end = headers[i + 1].start() if i + 1 < len(headers) else len(section)
+        body = section[start:end].strip()
+        phases.append(parse_phase_block(h.group(1), h.group(2).strip(), body))
+    if not phases:
+        raise ValueError("No '### Phase NN' subsections found in 'Phased build' section.")
+    return phases
+
+
+def resolve_depends(phases: list[Phase]) -> None:
+    """Resolve PHASE-NN tokens in depends_on to actual task slugs."""
+    by_num = {p.number: p for p in phases}
+    for p in phases:
+        new_deps: list[str] = []
+        for d in p.depends_on:
+            m = re.match(r"PHASE-(\d+)", d)
+            if m and m.group(1) in by_num:
+                target = by_num[m.group(1)]
+                if target.parallel_items:
+                    # Depend on every fan-out child.
+                    for item in target.parallel_items:
+                        new_deps.append(f"phase-{target.number}-{target.slug}-{slugify(item)}")
+                else:
+                    new_deps.append(f"phase-{target.number}-{target.slug}")
+            else:
+                new_deps.append(d)
+        p.depends_on = new_deps
+
+
+def render_task_file(
+    phase: Phase,
+    item: str | None,
+    standards: list[str],
+    plan_path: str,
+) -> tuple[str, str]:
+    """Render (filename, content) for a single task file."""
+    if item:
+        slug = f"{phase.slug}-{slugify(item)}"
+        title = f"[Phase {phase.number}/{item}] {phase.name}"
+        approach_extra = f"\nThis task is the **{item}** fan-out of phase {phase.number}.\n"
+    else:
+        slug = phase.slug
+        title = f"[Phase {phase.number}] {phase.name}"
+        approach_extra = ""
+
+    frontmatter: dict[str, Any] = {
+        "title": title,
+        "phase": f"phase-{phase.number}",
+        "slug": slug,
+        "preferred-agent": "copilot",
+        "preflight-confirmation": False,
+        "goal": phase.name,
+        "acceptance-criteria": [phase.done_check],
+        "files-to-touch": ["**"],  # Plan-level; task files may narrow this manually.
+        "files-not-to-touch": [
+            "AGENTS.md",
+            ".github/copilot-instructions.md",
+            "audit-log/**",
+            "policies/**",
+            "dhf/**",
+        ],
+        "tests-required": "Per the Done check in the issue body. CI must be green.",
+        "rollback": "Revert the merge commit on this PR.",
+        "estimated-complexity": "m",
+    }
+    if phase.depends_on:
+        frontmatter["depends-on"] = phase.depends_on
+    if standards:
+        frontmatter["standards"] = standards
+
+    fm_yaml = yaml.safe_dump(frontmatter, sort_keys=False, default_flow_style=False).strip()
+
+    body = f"""---
+{fm_yaml}
+---
+
+## Context
+
+This task is generated from the plan at `{plan_path}`. Read that plan in full
+before editing. The plan is the source of truth for architecture, file layout,
+and acceptance criteria.
+
+Standing rules from `AGENTS.md` and `.github/copilot-instructions.md` apply
+and take precedence over anything in this task body if there is conflict.
+{approach_extra}
+
+## Approach
+
+Execute the following steps in order. Stop after this phase. Do not start
+the next phase even if it appears unblocked.
+
+"""
+    if phase.steps:
+        for i, step in enumerate(phase.steps, 1):
+            body += f"{i}. {step}\n"
+    else:
+        body += f"_No explicit steps in the plan for this phase. Use the plan section verbatim._\n\n```\n{phase.raw_body}\n```\n"
+
+    body += f"""
+
+## Verification
+
+```bash
+# Replace with the exact done-check command(s) from the plan.
+# Done check from plan: {phase.done_check}
+```
+
+## References
+
+- Build plan: `{plan_path}`
+- Org standards: `AGENTS.md`, `.github/copilot-instructions.md`
+- Task schema: `copilot-tasks/_schema.md`
+"""
+
+    filename = f"task-{phase.number}-{slug}.md"
+    return filename, body
+
+
+def write_tasks(
+    phases: list[Phase],
+    target_repo: Path,
+    plan_path: str,
+    standards: list[str],
+    dry_run: bool,
+) -> None:
+    base = target_repo / "copilot-tasks"
+    base.mkdir(parents=True, exist_ok=True)
+
+    for phase in phases:
+        phase_dir = base / f"phase-{phase.number}-{phase.slug}"
+        phase_dir.mkdir(parents=True, exist_ok=True)
+
+        items: list[str | None] = phase.parallel_items if phase.parallel_items else [None]
+        for item in items:
+            filename, content = render_task_file(phase, item, standards, plan_path)
+            path = phase_dir / filename
+
+            if path.exists():
+                existing = path.read_text(encoding="utf-8")
+                if "# converter-managed: false" in existing:
+                    print(f"[skip] {path} (pinned)")
+                    continue
+                if existing == content:
+                    print(f"[ok]   {path} (unchanged)")
+                    continue
+                action = "update"
+            else:
+                action = "create"
+
+            if dry_run:
+                print(f"[{action}] {path} (dry-run)")
+            else:
+                path.write_text(content, encoding="utf-8")
+                print(f"[{action}] {path}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--plan", required=True, help="Path to the build plan markdown file.")
+    p.add_argument("--target-repo", required=True, help="Path to the target repo root.")
+    p.add_argument(
+        "--standards",
+        default="",
+        help="Comma-separated list of standards (e.g., 'CMS FY2026,IEC 62304').",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Print what would be written.")
+    args = p.parse_args()
+
+    plan_path = Path(args.plan).resolve()
+    target_repo = Path(args.target_repo).resolve()
+    if not plan_path.exists():
+        print(f"error: plan not found: {plan_path}", file=sys.stderr)
+        return 2
+    if not target_repo.is_dir():
+        print(f"error: target repo not a directory: {target_repo}", file=sys.stderr)
+        return 2
+
+    text = plan_path.read_text(encoding="utf-8")
+    phases = parse_phases(text)
+    resolve_depends(phases)
+    standards = [s.strip() for s in args.standards.split(",") if s.strip()]
+
+    print(f"Found {len(phases)} phases in {plan_path.name}:")
+    for ph in phases:
+        suffix = f" (×{len(ph.parallel_items)} fan-out)" if ph.parallel_items else ""
+        deps = f" depends-on={ph.depends_on}" if ph.depends_on else ""
+        print(f"  phase-{ph.number} {ph.slug}{suffix}{deps}")
+
+    write_tasks(phases, target_repo, str(plan_path.relative_to(target_repo) if target_repo in plan_path.parents else plan_path), standards, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sprint-init.sh
+++ b/scripts/sprint-init.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# sprint-init.sh — adopt the sprint standard in a target repo.
+#
+# Usage:
+#   sprint-init.sh <path-to-target-repo>
+#
+# This script:
+#   1. Validates the target repo is a git repo with a clean working tree.
+#   2. Creates a branch `chore/adopt-sprint-standard-v1`.
+#   3. Copies the sprint-bundle template (devcontainer, scripts, README block).
+#   4. Adds a `.github/copilot-instructions.md` reference if missing.
+#   5. Opens a PR for human review.
+#
+# Idempotent: if files already exist with identical content, leaves them alone.
+set -euo pipefail
+
+TARGET="${1:-}"
+if [[ -z "$TARGET" ]]; then
+  echo "usage: $0 <path-to-target-repo>" >&2
+  exit 2
+fi
+TARGET="$(cd "$TARGET" && pwd)"
+
+# Locate the bundle (in the same checkout this script lives in).
+BUNDLE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/templates/sprint-bundle"
+
+if [[ ! -d "$BUNDLE_ROOT" ]]; then
+  echo "error: sprint-bundle template not found at $BUNDLE_ROOT" >&2
+  exit 2
+fi
+
+cd "$TARGET"
+
+# Pre-flight
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "error: $TARGET is not a git repo" >&2; exit 2
+fi
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "error: working tree is not clean. Commit or stash first." >&2; exit 2
+fi
+
+git fetch origin
+DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo main)"
+git checkout "$DEFAULT_BRANCH"
+git pull --ff-only
+
+BRANCH="chore/adopt-sprint-standard-v1"
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  echo "==> Branch $BRANCH already exists; switching to it."
+  git checkout "$BRANCH"
+else
+  git checkout -b "$BRANCH"
+fi
+
+# Copy bundle contents.
+echo "==> Copying sprint-bundle template..."
+cp -nr "$BUNDLE_ROOT"/.devcontainer .devcontainer 2>/dev/null || true
+mkdir -p scripts && cp -n "$BUNDLE_ROOT"/scripts/* scripts/ 2>/dev/null || true
+mkdir -p docs/sprint-retros
+[[ -f "$BUNDLE_ROOT"/SPRINT_RETRO_TEMPLATE.md ]] && cp -n "$BUNDLE_ROOT"/SPRINT_RETRO_TEMPLATE.md docs/
+
+# Mark scripts executable.
+chmod +x .devcontainer/postcreate.sh .devcontainer/poststart.sh 2>/dev/null || true
+chmod +x scripts/*.sh 2>/dev/null || true
+
+# Ensure copilot-instructions.md references the standard.
+mkdir -p .github
+if [[ ! -f .github/copilot-instructions.md ]]; then
+  cat > .github/copilot-instructions.md <<'EOF'
+# Copilot agent instructions
+
+This repo follows the ruralpeds sprint standard. See:
+  - `docs/SPRINT_STANDARD.md` (org-level: ruralpeds/.github)
+  - `AGENTS.md` (org-level: ruralpeds/.github)
+  - The build plan committed at the repo root (`*_BUILD_PLAN.md`).
+
+Before any change, read both. Standing rules:
+- Branch convention: `agent/<phase>/<slug>-<issue#>`.
+- One task per PR. Diffs under 400 lines.
+- Tests required for every behavior change.
+- Refuse work on issues labeled `blocked:*` until the label is removed.
+EOF
+fi
+
+git add .devcontainer scripts docs .github
+if git diff --cached --quiet; then
+  echo "==> No changes to commit (already adopted)."
+  exit 0
+fi
+
+git commit -m "chore: adopt sprint-standard v1
+
+Adds .devcontainer/, scripts/sprint-kickoff.sh, scripts/plan_to_tasks.py,
+docs/sprint-retros/, and a baseline .github/copilot-instructions.md.
+
+Refs: ruralpeds/.github docs/SPRINT_STANDARD.md"
+
+git push -u origin "$BRANCH"
+gh pr create --fill --base "$DEFAULT_BRANCH" --title "chore: adopt sprint-standard v1" --body "$(cat <<'EOF'
+Adopts the ruralpeds sprint standard v1.
+
+This adds:
+- `.devcontainer/` — VS Code dev container pinned to `ghcr.io/ruralpeds/sprint-base:v1`
+- `scripts/plan_to_tasks.py` — converter from Claude build plan → copilot-tasks/*.md
+- `scripts/sprint-kickoff.sh` — seeds GitHub issues from copilot-tasks/ and assigns @copilot
+- `docs/sprint-retros/` — directory for per-phase retros
+- `.github/copilot-instructions.md` — baseline (if not already present)
+
+After merging, run:
+
+```bash
+# 1. Author a build plan in the repo root (via Claude)
+# 2. Convert plan → tasks
+python scripts/plan_to_tasks.py --plan MY_BUILD_PLAN.md --target-repo .
+# 3. Commit the tasks
+git add copilot-tasks && git commit -m "chore: add tasks for MY_BUILD_PLAN" && git push
+# 4. Kickoff
+./scripts/sprint-kickoff.sh --repo \$GITHUB_REPOSITORY
+```
+
+See `docs/SPRINT_STANDARD.md` in `ruralpeds/.github` for the full spec.
+EOF
+)"
+
+echo "==> Done. Open the PR for review."

--- a/scripts/sprint-kickoff.sh
+++ b/scripts/sprint-kickoff.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# sprint-kickoff.sh — seed GitHub issues from copilot-tasks/ and assign to @copilot.
+#
+# Usage:
+#   sprint-kickoff.sh --repo <owner/repo> [--phase <NN>] [--dry-run]
+#
+# Requires: gh CLI authenticated, target repo cloned locally, `copilot-tasks/`
+# directory populated (typically by plan_to_tasks.py).
+#
+# This script wraps the existing seed_issues.py from ruralpeds/.github so a
+# single command kicks off either one phase or all phases at once.
+set -euo pipefail
+
+REPO=""
+PHASE="all"
+DRY_RUN=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)    REPO="$2"; shift 2 ;;
+    --phase)   PHASE="$2"; shift 2 ;;
+    --dry-run) DRY_RUN="--dry-run"; shift ;;
+    -h|--help)
+      sed -n '2,12p' "$0"; exit 0 ;;
+    *)
+      echo "error: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$REPO" ]]; then
+  echo "error: --repo <owner/repo> is required" >&2
+  exit 2
+fi
+
+# Sanity checks
+if ! command -v gh >/dev/null; then
+  echo "error: gh CLI not installed" >&2; exit 2
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: gh CLI not authenticated. Run: gh auth login" >&2; exit 2
+fi
+if [[ ! -d copilot-tasks ]]; then
+  echo "error: copilot-tasks/ not found. Run plan_to_tasks.py first." >&2; exit 2
+fi
+
+# Locate seed_issues.py — prefer local, fall back to the org-level copy.
+SEEDER=""
+if [[ -f scripts/seed_issues.py ]]; then
+  SEEDER="scripts/seed_issues.py"
+elif [[ -d /tmp/ruralpeds-github/scripts ]]; then
+  SEEDER="/tmp/ruralpeds-github/scripts/seed_issues.py"
+else
+  echo "info: cloning ruralpeds/.github for seed_issues.py..."
+  gh repo clone ruralpeds/.github /tmp/ruralpeds-github -- --depth 1 >/dev/null
+  SEEDER="/tmp/ruralpeds-github/scripts/seed_issues.py"
+fi
+
+echo "==> Seeding issues from copilot-tasks/ into $REPO (phase=$PHASE)..."
+GH_TOKEN="$(gh auth token)" python3 "$SEEDER" \
+  --phase "$PHASE" \
+  --repo "$REPO" \
+  --assignee "copilot-swe-agent" \
+  $DRY_RUN
+
+echo "==> Done. View issues at: https://github.com/$REPO/issues?q=label%3Aagent-task"

--- a/templates/sprint-base.Dockerfile
+++ b/templates/sprint-base.Dockerfile
@@ -1,0 +1,55 @@
+# ruralpeds sprint-base v1
+# Built and pushed to ghcr.io/ruralpeds/sprint-base:v1
+# This image is consumed by every repo's .devcontainer/devcontainer.json.
+
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ARG NODE_VERSION=22
+ARG RUST_VERSION=stable
+ARG JULIA_VERSION=1.11.3
+ARG PYTHON_VERSION=3.12
+
+# System deps
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      build-essential pkg-config curl wget git ca-certificates \
+      libssl-dev libffi-dev zlib1g-dev \
+      postgresql-client \
+      jq ripgrep fd-find bat \
+      shellcheck yamllint \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust + wasm-pack + wasm32 target
+USER vscode
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile default
+ENV PATH=/home/vscode/.cargo/bin:$PATH
+RUN rustup target add wasm32-unknown-unknown \
+    && cargo install --locked wasm-pack wasm-bindgen-cli cargo-watch cargo-edit cargo-audit cargo-deny
+
+# Node + pnpm
+USER root
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g pnpm@latest pin-github-action
+
+# Python tools
+RUN pip install --break-system-packages --no-cache-dir uv pipx pre-commit ruff black mypy pytest
+
+# Julia
+RUN curl -fsSL https://install.julialang.org | sh -s -- --yes --default-channel ${JULIA_VERSION}
+ENV PATH=/root/.juliaup/bin:$PATH
+USER vscode
+
+# Local tools
+USER root
+RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | bash -s -- -b /usr/local/bin
+
+# GitHub CLI extensions used by sprint workflows
+USER vscode
+RUN gh extension install github/gh-copilot 2>/dev/null || true
+
+WORKDIR /workspaces
+
+LABEL org.opencontainers.image.source=https://github.com/ruralpeds/.github
+LABEL org.opencontainers.image.description="ruralpeds sprint runtime base"
+LABEL org.opencontainers.image.licenses=MIT

--- a/templates/sprint-bundle/.devcontainer/devcontainer.json
+++ b/templates/sprint-bundle/.devcontainer/devcontainer.json
@@ -1,0 +1,76 @@
+{
+  "name": "ruralpeds sprint runtime",
+  "image": "ghcr.io/ruralpeds/sprint-base:v1",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest",
+      "moby": true
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "GitHub.vscode-pull-request-github",
+        "rust-lang.rust-analyzer",
+        "tauri-apps.tauri-vscode",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "julialang.language-julia",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml",
+        "tamasfe.even-better-toml",
+        "bradlc.vscode-tailwindcss",
+        "yzhang.markdown-all-in-one",
+        "GitHub.vscode-github-actions"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.fixAll": "explicit"
+        },
+        "rust-analyzer.checkOnSave": true,
+        "rust-analyzer.cargo.targetDir": true,
+        "[python]": { "editor.defaultFormatter": "ms-python.python" },
+        "[rust]": { "editor.defaultFormatter": "rust-lang.rust-analyzer" },
+        "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+        "[typescriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+        "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+        "[markdown]": { "editor.formatOnSave": false },
+        "github.copilot.enable": {
+          "*": true,
+          "yaml": true,
+          "plaintext": false,
+          "markdown": true
+        },
+        "github.copilot.chat.codesearch.enabled": true,
+        "github.copilot.chat.agent.enabled": true
+      }
+    }
+  },
+  "remoteUser": "vscode",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "mounts": [
+    "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,readonly",
+    "source=${localWorkspaceFolderBasename}-cargo-cache,target=/home/vscode/.cargo,type=volume",
+    "source=${localWorkspaceFolderBasename}-node-cache,target=/workspaces/${localWorkspaceFolderBasename}/node_modules,type=volume"
+  ],
+  "postCreateCommand": "bash .devcontainer/postcreate.sh",
+  "postStartCommand": "bash .devcontainer/poststart.sh",
+  "containerEnv": {
+    "RUST_BACKTRACE": "1",
+    "CARGO_INCREMENTAL": "0",
+    "RUSTFLAGS": "-D warnings"
+  },
+  "forwardPorts": [3000, 5173, 8080, 1420],
+  "portsAttributes": {
+    "5173": { "label": "Vite dev server", "onAutoForward": "openBrowser" },
+    "1420": { "label": "Tauri dev",        "onAutoForward": "ignore" }
+  }
+}

--- a/templates/sprint-bundle/.devcontainer/postcreate.sh
+++ b/templates/sprint-bundle/.devcontainer/postcreate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# postcreate.sh — runs once after the devcontainer is built.
+# This is where per-repo setup happens (deps, hooks, sanity checks).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "==> ruralpeds sprint runtime: post-create"
+
+# Verify gh auth is mounted and works.
+if gh auth status >/dev/null 2>&1; then
+  echo "✓ gh CLI authenticated as $(gh api user --jq .login)"
+else
+  echo "⚠ gh CLI is NOT authenticated. The cloud agent uses GITHUB_TOKEN automatically;"
+  echo "  if you are a human contributor, run: gh auth login"
+fi
+
+# Install pre-commit hooks if config exists.
+if [[ -f .pre-commit-config.yaml ]]; then
+  pre-commit install --install-hooks
+fi
+
+# Language-specific bootstrap (each is a no-op if not applicable).
+if [[ -f Cargo.toml ]]; then
+  echo "==> Rust workspace detected"
+  rustup show
+  cargo fetch --locked || cargo fetch
+fi
+
+if [[ -f package.json ]]; then
+  echo "==> Node project detected"
+  if command -v pnpm >/dev/null && [[ -f pnpm-lock.yaml ]]; then
+    pnpm install --frozen-lockfile
+  elif [[ -f package-lock.json ]]; then
+    npm ci
+  else
+    npm install
+  fi
+fi
+
+if [[ -f ui/package.json ]]; then
+  echo "==> ui/ workspace detected"
+  ( cd ui && (command -v pnpm >/dev/null && [[ -f pnpm-lock.yaml ]] && pnpm install --frozen-lockfile || npm ci || npm install) )
+fi
+
+if [[ -f Project.toml ]]; then
+  echo "==> Julia project detected"
+  julia --project=. -e 'using Pkg; Pkg.instantiate()'
+fi
+
+if [[ -f pyproject.toml ]]; then
+  echo "==> Python project detected"
+  if command -v uv >/dev/null; then
+    uv sync || true
+  else
+    pip install --user -e . || true
+  fi
+fi
+
+echo "==> Done."

--- a/templates/sprint-bundle/.devcontainer/poststart.sh
+++ b/templates/sprint-bundle/.devcontainer/poststart.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# poststart.sh — runs every time the devcontainer starts.
+# Quick reminders for human and agent contributors.
+set -euo pipefail
+
+cat <<'EOF'
+
+╭──────────────────────────────────────────────────────────────╮
+│  ruralpeds sprint runtime — ready                            │
+│                                                              │
+│  Sprint loop:                                                │
+│    1. Read the build plan in the repo root.                  │
+│    2. Pick an unblocked task in copilot-tasks/phase-NN-*/    │
+│    3. For VS Code agent mode: use Copilot Chat → @copilot.   │
+│    4. For cloud agent: assign the linked GitHub issue.       │
+│    5. Branch convention: agent/<phase>/<slug>-<issue#>       │
+│                                                              │
+│  Standards (do not edit without an explicit task):           │
+│    - AGENTS.md                                               │
+│    - .github/copilot-instructions.md                         │
+│    - copilot-tasks/_schema.md                                │
+╰──────────────────────────────────────────────────────────────╯
+
+EOF

--- a/templates/sprint-bundle/SPRINT_RETRO_TEMPLATE.md
+++ b/templates/sprint-bundle/SPRINT_RETRO_TEMPLATE.md
@@ -1,0 +1,25 @@
+# Sprint Retro: Phase NN — <name>
+
+> **Repo**: <repo>
+> **Phase**: phase-NN
+> **Plan**: `<PLAN.md>`
+> **Sprint window**: <YYYY-MM-DD> → <YYYY-MM-DD>
+> **PRs**: #NN, #NN, ...
+
+## What went well
+
+<one or two sentences>
+
+## What needed re-prompting
+
+<the prompt that fixed the drift; copy verbatim if useful>
+
+## What I would change in the plan
+
+<one or two sentences; if "nothing", say so>
+
+## Keep the same phase boundaries next time?
+
+- [ ] Yes
+- [ ] No — split this phase
+- [ ] No — combine with adjacent phase


### PR DESCRIPTION
Adds a repeatable Claude-plan -> Copilot-sprint pattern that composes with the existing AGENTS.md, copilot-tasks/_schema.md, and seed_issues.py. Three new layers:

- Plan: <PROJECT>_BUILD_PLAN.md authored in Claude
- Sprints: copilot-tasks/*.md generated by plan_to_tasks.py
- Runtime: .devcontainer pinned to ghcr.io/ruralpeds/sprint-base:v1 so VS Code agent mode and the cloud agent share the same Docker env

New artifacts:
- docs/SPRINT_STANDARD.md - the standard
- docs/PLAN_AUTHORING_RUBRIC.md - how to author plans Claude-style
- scripts/plan_to_tasks.py - converter (deterministic, idempotent)
- scripts/sprint-init.sh - adopt in a target repo
- scripts/sprint-kickoff.sh - seed issues from copilot-tasks/
- templates/sprint-base.Dockerfile - base image for devcontainers
- templates/sprint-bundle/ - files copied into target repos by init

First adopter: ruralpeds/hospital-economics-rust UI build.

Refs: docs/SPRINT_STANDARD.md