### PR TITLE
ci: phase 4 — migrate 8 admin/event workflows to mac-studio runner

### DIFF
--- a/.github/workflows/copilot-task-guardrails.yml
+++ b/.github/workflows/copilot-task-guardrails.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   detect-agent:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     outputs:
       is-agent: ${{ steps.check.outputs.is-agent }}
       agent-name: ${{ steps.check.outputs.agent-name }}
@@ -83,7 +83,7 @@ jobs:
   forbidden-paths:
     needs: detect-agent
     if: needs.detect-agent.outputs.is-agent == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -147,7 +147,7 @@ jobs:
   required-compliance-checks-preserved:
     needs: detect-agent
     if: needs.detect-agent.outputs.is-agent == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -185,7 +185,7 @@ jobs:
   pr-description-complete:
     needs: detect-agent
     if: needs.detect-agent.outputs.is-agent == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - name: Verify PR description has all required sections
         env:
@@ -243,7 +243,7 @@ jobs:
       (needs.detect-agent.outputs.repo-class == 'class-b' ||
        needs.detect-agent.outputs.repo-class == 'class-c' ||
        needs.detect-agent.outputs.data-class == 'phi-active')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - name: Require human-review label
         env:
@@ -257,7 +257,7 @@ jobs:
   audit-log-agent-pr:
     needs: [detect-agent, forbidden-paths, required-compliance-checks-preserved, pr-description-complete]
     if: always() && needs.detect-agent.outputs.is-agent == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - name: Emit audit event for agent PR
         env:

--- a/.github/workflows/gap-analysis-sync-index.yml
+++ b/.github/workflows/gap-analysis-sync-index.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     
     steps:
       - name: Checkout

--- a/.github/workflows/gap-analysis-validate.yml
+++ b/.github/workflows/gap-analysis-validate.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     
     steps:
       - name: Checkout

--- a/.github/workflows/origin-label.yml
+++ b/.github/workflows/origin-label.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   check:
     name: Verify origin label
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 3
     if: ${{ github.event.pull_request.draft == false || inputs.required-for-draft }}
     permissions:

--- a/.github/workflows/playwright-audit.yml
+++ b/.github/workflows/playwright-audit.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   playwright-audit:
     name: Playwright CI audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
       issues: write
@@ -32,6 +32,11 @@ jobs:
 
       - name: Install Node dependencies
         run: npm ci
+
+      - name: Install Playwright browsers (cached on self-hosted)
+        # On self-hosted runners browser binaries persist between runs.
+        # This is a no-op after the first install; --with-deps is macOS-safe.
+        run: npx playwright install chromium --with-deps 2>/dev/null || true
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/post-market-tracker.yml
+++ b/.github/workflows/post-market-tracker.yml
@@ -36,7 +36,7 @@ jobs:
     if: >
       github.event.action == 'labeled' && github.event.label.name == 'post-market' ||
       github.event.action == 'edited' && contains(toJSON(github.event.issue.labels), '"post-market"')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ permissions:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     outputs:
       version: ${{ steps.version.outputs.new_version }}
       tag: ${{ steps.version.outputs.new_tag }}

--- a/.github/workflows/sync-rulesets.yml
+++ b/.github/workflows/sync-rulesets.yml
@@ -51,7 +51,7 @@ permissions:
 jobs:
   sync:
     name: Apply rulesets to org repos
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 15
     permissions:
       contents: write   # to commit ledger entry


### PR DESCRIPTION
Workflows migrated (ubuntu-latest → [self-hosted, mac-studio, arm64]):
  - copilot-task-guardrails.yml  (6 jobs — fires on every Copilot agent PR)
  - sync-rulesets.yml            (push-triggered)
  - gap-analysis-sync-index.yml  (push-triggered)
  - gap-analysis-validate.yml    (push-triggered)
  - origin-label.yml             (PR/workflow_call-triggered)
  - post-market-tracker.yml      (issue-label triggered)
  - playwright-audit.yml         (weekly Monday + browser install step added)
  - release.yml                  (workflow_call — git/gh only, no OIDC)

copilot-task-guardrails.yml is the highest-frequency workflow in this batch: it fires on every PR opened by the Copilot agent (which generates PRs for every sprint task across all org repos). 6 ubuntu-latest jobs per trigger eliminated.

playwright-audit.yml: added 'npx playwright install chromium --with-deps' step. On self-hosted runners browser binaries persist, making this a fast no-op after the first run.