### PR TITLE
ci: phase 6 — final ubuntu-latest cleanup pass

### DIFF
--- a/.github/workflows/ci-content.yml
+++ b/.github/workflows/ci-content.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   lint:
     name: Lint Markdown Content
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
@@ -63,7 +63,7 @@ jobs:
 
   security:
     name: Security Checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
@@ -81,7 +81,7 @@ jobs:
 
   sbom:
     name: Generate SBOM
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4

--- a/.github/workflows/reusable-container-scan.yml
+++ b/.github/workflows/reusable-container-scan.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   scan:
     name: Vulnerability scan (${{ inputs.target-type || 'auto' }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/reusable-validation-export.yml
+++ b/.github/workflows/reusable-validation-export.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   export:
     name: Export validation package
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/review-stamp-v2.yml
+++ b/.github/workflows/review-stamp-v2.yml
@@ -77,7 +77,7 @@ permissions:
 jobs:
   review:
     name: Record e-signature
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/review-stamp.yml
+++ b/.github/workflows/review-stamp.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   review-stamp:
     name: Stamp code review
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Last 5 workflows migrated to [self-hosted, mac-studio, arm64]:

  ci-content.yml              (3 jobs — markdown lint, link check, doc validation)
  review-stamp.yml            (1 job — workflow_dispatch only)
  review-stamp-v2.yml         (1 job — workflow_dispatch only)
  reusable-container-scan.yml (1 job — trivy/grype; upload-sarif via codeql-action
                                works on self-hosted with security-events:write)
  reusable-validation-export.yml (1 job — cosign reference was a doc comment, not
                                  an actual signing step)

After all phases merge, ubuntu-latest is retained ONLY for:
  - OIDC keyless cosign/Sigstore signing (audit-log, audit-sign-envelope, reusable-attest, reusable-sign-artifact, reusable-slsa-provenance, reusable-container-sign, reusable-sbom, reusable-vex, reusable-release)
  - Docker buildx (build-sprint-base, container)
  - Copilot agent setup (copilot-setup-steps — Linux-specific binaries/apt-get)
  - CodeQL analysis (2 jobs in code-quality.yml)
  - Intentional regulatory decisions (audit-verify)
  - Negligible-cost scheduled jobs (dependency-eol monthly, reusable-chaos-test bi-monthly)