### PR TITLE
ci: phase 5 — migrate CI language and reusable workflows to mac-studi…

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   detect:
     name: Detect configuration
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     outputs:
       has-tests: ${{ steps.check.outputs.has-tests }}
       matrix: ${{ steps.matrix.outputs.versions }}
@@ -70,7 +70,7 @@ jobs:
   lint:
     name: Lint
     if: inputs.run-lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5
@@ -86,7 +86,7 @@ jobs:
   vet:
     name: Vet
     if: inputs.run-vet
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5
@@ -99,7 +99,7 @@ jobs:
   security:
     name: Security scan
     if: inputs.run-security
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed  # v5
@@ -135,7 +135,7 @@ jobs:
     name: "Test (Go ${{ matrix.go-version }})"
     needs: detect
     if: needs.detect.outputs.has-tests == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: ${{ fromJson(inputs.test-timeout) }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-julia.yml
+++ b/.github/workflows/ci-julia.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   test:
     name: Julia Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     strategy:
       matrix:
         julia-version: ['1.8', '1.9', '1.10']
@@ -59,7 +59,7 @@ jobs:
 
   lint:
     name: Lint and Format
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
@@ -76,7 +76,7 @@ jobs:
 
   sbom:
     name: Generate SBOM
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
@@ -123,7 +123,7 @@ jobs:
 
   security:
     name: Security Checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -43,7 +43,7 @@ on:
 jobs:
   detect:
     name: Detect configuration
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     outputs:
       has-lint: ${{ steps.check.outputs.has-lint }}
       has-typecheck: ${{ steps.check.outputs.has-typecheck }}
@@ -80,7 +80,7 @@ jobs:
     name: Lint
     needs: detect
     if: needs.detect.outputs.has-lint == 'true' && inputs.run-lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4
@@ -108,7 +108,7 @@ jobs:
     name: Type check
     needs: detect
     if: needs.detect.outputs.has-typecheck == 'true' && inputs.run-typecheck
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4
@@ -136,7 +136,7 @@ jobs:
     name: Security audit
     needs: detect
     if: inputs.run-security-audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4
@@ -164,7 +164,7 @@ jobs:
     name: "Test (Node ${{ matrix.node-version }})"
     needs: detect
     if: needs.detect.outputs.has-test == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: ${{ fromJson(inputs.test-timeout) }}
     strategy:
       fail-fast: false
@@ -215,7 +215,7 @@ jobs:
     name: Build
     needs: [detect, test]
     if: needs.detect.outputs.has-build == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   detect:
     name: Detect configuration
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     outputs:
       has-tests: ${{ steps.check.outputs.has-tests }}
       matrix: ${{ steps.matrix.outputs.versions }}
@@ -71,7 +71,7 @@ jobs:
     name: Lint
     needs: detect
     if: inputs.run-lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5
@@ -90,7 +90,7 @@ jobs:
     name: Type check (mypy)
     needs: detect
     if: inputs.run-typecheck
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5
@@ -111,7 +111,7 @@ jobs:
     name: Security scan
     needs: detect
     if: inputs.run-security
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5
@@ -149,7 +149,7 @@ jobs:
     name: "Test (Python ${{ matrix.python-version }})"
     needs: detect
     if: needs.detect.outputs.has-tests == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: ${{ fromJson(inputs.test-timeout) }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -36,7 +36,7 @@ jobs:
   fmt:
     name: Format check
     if: inputs.run-fmt
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248  # stable
@@ -49,7 +49,7 @@ jobs:
   clippy:
     name: Clippy
     if: inputs.run-clippy
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248  # stable
@@ -70,7 +70,7 @@ jobs:
   security-audit:
     name: Security audit
     if: inputs.run-security-audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - name: Install cargo-audit
@@ -81,7 +81,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: ${{ fromJson(inputs.test-timeout) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
@@ -114,7 +114,7 @@ jobs:
   coverage:
     name: Coverage
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248  # stable

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -138,7 +138,7 @@ jobs:
   dependency-review:
     name: Dependency review
     if: inputs.run-dependency-review && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
       pull-requests: write
@@ -157,7 +157,7 @@ jobs:
   license-check:
     name: License compliance
     if: inputs.run-license-check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
@@ -248,7 +248,7 @@ jobs:
   repo-hygiene:
     name: Repository hygiene
     if: inputs.run-repo-hygiene
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - name: Check required files

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -63,7 +63,7 @@ on:
 jobs:
   install:
     name: Install & cache
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4
@@ -90,7 +90,7 @@ jobs:
   test:
     name: "E2E (${{ matrix.browser }}${{ inputs.shards > 1 && format(', shard {0}/{1}', matrix.shard, inputs.shards) || '' }})"
     needs: install
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: ${{ fromJson(inputs.test-timeout) }}
     strategy:
       fail-fast: false
@@ -209,7 +209,7 @@ jobs:
     name: Merge reports
     needs: test
     if: always() && inputs.upload-report
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4

--- a/.github/workflows/reusable-ci-julia.yml
+++ b/.github/workflows/reusable-ci-julia.yml
@@ -42,7 +42,7 @@ jobs:
   # ── 0. Pre-flight: detect config and build version matrix ─────────────────────
   detect:
     name: Detect configuration
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     outputs:
@@ -83,7 +83,7 @@ jobs:
     name: Format check (JuliaFormatter)
     needs: detect
     if: ${{ inputs.run-format-check && needs.detect.outputs.has-project == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     steps:
@@ -112,7 +112,7 @@ jobs:
     name: "Test (Julia ${{ matrix.julia-version }})"
     needs: detect
     if: ${{ needs.detect.outputs.has-tests == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: ${{ fromJson(inputs.test-timeout-minutes) }}
     permissions:
       contents: read

--- a/.github/workflows/reusable-ci-rust.yml
+++ b/.github/workflows/reusable-ci-rust.yml
@@ -51,7 +51,7 @@ jobs:
   fmt:
     name: Rustfmt
     if: ${{ inputs.run-fmt }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     steps:
@@ -69,7 +69,7 @@ jobs:
   clippy:
     name: Clippy
     if: ${{ inputs.run-clippy }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     steps:
@@ -95,7 +95,7 @@ jobs:
   # ── 3. Tests (stable) ────────────────────────────────────────────────────────
   test-stable:
     name: "Test (stable)"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: ${{ fromJson(inputs.test-timeout-minutes) }}
     permissions:
       contents: read
@@ -141,7 +141,7 @@ jobs:
   test-nightly:
     name: "Test (nightly)"
     if: ${{ inputs.run-nightly }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: ${{ fromJson(inputs.test-timeout-minutes) }}
     permissions:
       contents: read

--- a/.github/workflows/reusable-contract.yml
+++ b/.github/workflows/reusable-contract.yml
@@ -51,7 +51,7 @@ permissions:
 jobs:
   fhir:
     name: Validate FHIR resources
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -42,7 +42,7 @@ jobs:
   markdown-lint:
     name: Markdown lint
     if: ${{ inputs.run-markdown-lint }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     steps:
@@ -67,7 +67,7 @@ jobs:
   link-check:
     name: Link check
     if: ${{ inputs.run-link-check }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     steps:
@@ -93,7 +93,7 @@ jobs:
   required-docs:
     name: Required docs check
     if: ${{ inputs.run-required-docs-check }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/reusable-fhir-validation.yml
+++ b/.github/workflows/reusable-fhir-validation.yml
@@ -52,7 +52,7 @@ permissions:
 jobs:
   validate-fhir:
     name: Validate FHIR Resources
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 30
     outputs:
       validation_status: ${{ steps.validate.outputs.validation_status }}

--- a/.github/workflows/reusable-gap-analysis.yml
+++ b/.github/workflows/reusable-gap-analysis.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   lifecycle:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/reusable-iec62304-traceability.yml
+++ b/.github/workflows/reusable-iec62304-traceability.yml
@@ -55,7 +55,7 @@ permissions:
 jobs:
   traceability:
     name: IEC 62304 Traceability
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 15
     outputs:
       gap-count: ${{ steps.gaps.outputs.gap_count }}

--- a/.github/workflows/reusable-license-scan.yml
+++ b/.github/workflows/reusable-license-scan.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   license-scan:
     name: License compliance scan
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/reusable-mutation-test.yml
+++ b/.github/workflows/reusable-mutation-test.yml
@@ -47,7 +47,7 @@ permissions:
 jobs:
   mutation-test:
     name: Run Mutation Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 120
     outputs:
       kill_rate: ${{ steps.mutate.outputs.kill_rate }}

--- a/.github/workflows/reusable-mutation.yml
+++ b/.github/workflows/reusable-mutation.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   mutate:
     name: Mutation testing
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/reusable-phi-scan.yml
+++ b/.github/workflows/reusable-phi-scan.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   phi-scan:
     name: PHI scrubbing scan (${{ inputs.scan-mode }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/reusable-repo-standards.yml
+++ b/.github/workflows/reusable-repo-standards.yml
@@ -33,7 +33,7 @@ jobs:
   # ── 1. Governance and required file structure ─────────────────────────────────
   governance:
     name: Governance file check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     steps:
@@ -52,7 +52,7 @@ jobs:
   audit-events:
     name: Audit events catalog
     if: ${{ inputs.run-audit-events-check }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     steps:
@@ -74,7 +74,7 @@ jobs:
   pinning-advisory:
     name: Action pinning advisory
     if: ${{ inputs.run-pinning-advisory }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/reusable-risk-file.yml
+++ b/.github/workflows/reusable-risk-file.yml
@@ -49,7 +49,7 @@ permissions:
 jobs:
   aggregate:
     name: Aggregate hazard issues
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/reusable-rtm.yml
+++ b/.github/workflows/reusable-rtm.yml
@@ -66,7 +66,7 @@ permissions:
 jobs:
   rtm:
     name: Build RTM
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -44,7 +44,7 @@ jobs:
   dependency-review:
     name: Dependency review
     if: ${{ inputs.run-dependency-review && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
       pull-requests: write  # needed to post review comments
@@ -64,7 +64,7 @@ jobs:
   # credential patterns are accidentally committed in changed files.
   secret-scan-advisory:
     name: Secret scan advisory
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
     steps:
@@ -114,7 +114,7 @@ jobs:
   codeql:
     name: "CodeQL (${{ matrix.language }})"
     if: ${{ inputs.run-codeql && fromJson(inputs.codeql-languages)[0] != null }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     permissions:
       contents: read
       security-events: write  # required for SARIF upload

--- a/.github/workflows/reusable-synthea-fixtures.yml
+++ b/.github/workflows/reusable-synthea-fixtures.yml
@@ -55,7 +55,7 @@ permissions:
 jobs:
   generate-fixtures:
     name: Generate Synthea FHIR Bundles
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 45
     outputs:
       fixture_count: ${{ steps.generate.outputs.fixture_count }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,7 +39,7 @@ jobs:
   semgrep:
     name: "SAST (Semgrep)"
     if: inputs.run-semgrep
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 15
     permissions:
       security-events: write
@@ -98,7 +98,7 @@ jobs:
   secret-detection:
     name: Secret detection
     if: inputs.run-secret-detection
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
@@ -169,7 +169,7 @@ jobs:
   sbom:
     name: Generate SBOM
     if: inputs.run-sbom
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 10
     permissions:
       contents: read
@@ -246,7 +246,7 @@ jobs:
   supply-chain:
     name: Supply chain checks
     if: inputs.run-supply-chain
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4


### PR DESCRIPTION
…o runner

CI language workflows (all jobs → [self-hosted, mac-studio, arm64]):
  ci-rust.yml       (5 jobs)
  ci-python.yml     (5 jobs)
  ci-node.yml       (6 jobs)
  ci-go.yml         (5 jobs)
  ci-julia.yml      (4 jobs)
  reusable-ci-rust.yml   (4 jobs)
  reusable-ci-julia.yml  (3 jobs)

Security / quality workflows:
  security-scan.yml       (4 jobs)
  reusable-security.yml   (3 jobs)
  e2e-playwright.yml      (3 jobs)
  code-quality.yml        (3 of 5 jobs — detect-languages and codeql remain
                            on ubuntu-latest; GitHub CodeQL action requires
                            github-hosted runners for SARIF upload)

Reusable workflows (no OIDC/Docker dependency, 1–3 jobs each):
  reusable-docs.yml, reusable-repo-standards.yml, reusable-contract.yml,
  reusable-mutation.yml, reusable-mutation-test.yml, reusable-phi-scan.yml,
  reusable-fhir-validation.yml, reusable-risk-file.yml, reusable-rtm.yml,
  reusable-iec62304-traceability.yml, reusable-gap-analysis.yml,
  reusable-license-scan.yml, reusable-synthea-fixtures.yml

Workflows intentionally left on ubuntu-latest (OIDC/cosign/Docker):
  audit-log.yml, audit-sign-envelope.yml, reusable-attest.yml,
  reusable-sign-artifact.yml, reusable-slsa-provenance.yml,
  reusable-container-sign.yml, reusable-sbom.yml, reusable-vex.yml,
  reusable-release.yml, build-sprint-base.yml, container.yml,
  copilot-setup-steps.yml (Copilot agent environment — Linux-specific),
  audit-verify.yml (regulatory integrity argument),
  dependency-eol.yml (monthly, negligible cost),
  reusable-chaos-test.yml (bi-monthly, negligible cost)