### PR TITLE
ci: phase 7 — scope required-compliance push trigger to source-only p…

### DIFF
--- a/.github/workflows/required-compliance.yml
+++ b/.github/workflows/required-compliance.yml
@@ -5,10 +5,40 @@
 name: Required — Compliance
 
 on:
+  # PRs always get the full compliance gate — no exceptions.
   pull_request:
     branches: [main, master]
+
+  # Direct pushes to main/master skip the compliance run when the diff is
+  # purely documentary (docs, markdown, copilot task files, audit logs, etc.).
+  # Source code, workflow YAML, policy JSON, and Dockerfiles still trigger.
   push:
     branches: [main, master]
+    paths:
+      - 'src/**'
+      - '**.rs'
+      - '**.jl'
+      - '**.py'
+      - '**.go'
+      - '**.ts'
+      - '**.tsx'
+      - '**.js'
+      - '**.jsx'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Project.toml'
+      - 'Manifest.toml'
+      - 'requirements*.txt'
+      - 'pyproject.toml'
+      - 'go.mod'
+      - 'go.sum'
+      - 'package.json'
+      - 'package-lock.json'
+      - '*.dockerfile'
+      - '**/Dockerfile*'
+      - '.github/workflows/**'
+      - 'policy/**'
+      - '**/*.json'
 
 jobs:
   hipaa:


### PR DESCRIPTION
…aths

PRs continue to receive the full HIPAA compliance gate unconditionally.

Direct pushes to main/master now only trigger compliance when the diff touches actual source: Rust/Julia/Python/Go/TS/JS files, dependency manifests (Cargo.toml, Project.toml, pyproject.toml, go.mod, package.json), Dockerfiles, workflow YAML, or policy JSON.

Purely documentary commits — docs/, markdown, copilot task files, audit logs, compliance-metrics, textbooks, roadmaps — no longer spawn the full hipaa-compliance workflow chain (phi-scan, sast, sbom-generation, dependency-scan, license-compliance, coverage-gate, compliance-summary).

This is the highest-leverage push-trigger optimisation remaining: required-compliance is an org-level required workflow called from every ruralpeds repo on every push. The HIPAA workflow has 8 jobs including a phi-scan (Gitleaks + custom regex) and an SBOM generation step — expensive for a README edit.