### PR TITLE
feat(audit): org-wide clinical audit dashboard

### DIFF
--- a/.github/workflows/audit-dashboard-sweep.yml
+++ b/.github/workflows/audit-dashboard-sweep.yml
@@ -1,0 +1,130 @@
+name: Clinical Audit Dashboard
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fetches .clinical-audit/registry.yaml from every Rust and Julia repo in the
+# org, aggregates stats, and:
+#   1. Writes a markdown dashboard to $GITHUB_STEP_SUMMARY
+#   2. Commits audit-dashboard/DASHBOARD.md to ruralpeds/.github main
+#
+# Schedule: Sunday 23:00 UTC — runs before the Monday clinical-audit-sweep so
+# the dashboard reflects last week's state going into the new scan.
+#
+# Also triggered by workflow_dispatch for on-demand refreshes or single-repo
+# spot-checks.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  schedule:
+    - cron: "0 23 * * 0"   # Sunday 23:00 UTC
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: "Single repo name to include (blank = full org sweep)"
+        type: string
+        required: false
+        default: ""
+      commit_dashboard:
+        description: "Commit DASHBOARD.md back to .github repo"
+        type: boolean
+        required: false
+        default: true
+
+concurrency:
+  group: "audit-dashboard-sweep"
+  cancel-in-progress: false
+
+jobs:
+  dashboard:
+    name: Build clinical audit dashboard
+    runs-on: [self-hosted, mac-studio, arm64]
+    timeout-minutes: 20
+    permissions:
+      contents: write
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1  # v1.11.1
+        with:
+          app-id: ${{ secrets.TH_BOT_APP_ID }}
+          private-key: ${{ secrets.TH_BOT_PRIVATE_KEY }}
+          owner: ruralpeds
+
+      - name: Checkout ruralpeds/.github
+        uses: actions/checkout@v4  # v4.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          # Full checkout — we commit DASHBOARD.md back here
+          fetch-depth: 1
+
+      - name: Build dashboard
+        id: build
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          ARGS="--token $GH_TOKEN --org ruralpeds"
+          ARGS="$ARGS --output audit-dashboard/DASHBOARD.md"
+          ARGS="$ARGS --json-output /tmp/audit_dashboard.json"
+          if [ -n "${{ inputs.target_repo }}" ]; then
+            ARGS="$ARGS --repo ${{ inputs.target_repo }}"
+          fi
+
+          mkdir -p audit-dashboard
+
+          # Capture exit code (1 = flagged functions exist — not a script failure)
+          set +e
+          python3 scripts/build_audit_dashboard.py $ARGS >> "$GITHUB_STEP_SUMMARY"
+          EXIT=$?
+          set -e
+
+          echo "flagged_exit=$EXIT" >> "$GITHUB_OUTPUT"
+
+          # Summarise counts for subsequent steps
+          if [ -f /tmp/audit_dashboard.json ]; then
+            FLAGGED=$(jq '.flagged_count' /tmp/audit_dashboard.json)
+            STALE=$(jq '.stale_count' /tmp/audit_dashboard.json)
+            PENDING=$(jq '.totals.by_status.pending // 0' /tmp/audit_dashboard.json)
+            echo "flagged_count=$FLAGGED" >> "$GITHUB_OUTPUT"
+            echo "stale_count=$STALE"     >> "$GITHUB_OUTPUT"
+            echo "pending_count=$PENDING" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit dashboard
+        if: >-
+          (github.event_name == 'schedule' ||
+           inputs.commit_dashboard == true) &&
+          inputs.target_repo == ''
+        run: |
+          git config user.name  "ruralpeds-bot[bot]"
+          git config user.email "ruralpeds-bot[bot]@users.noreply.github.com"
+          git add audit-dashboard/DASHBOARD.md
+          if git diff --cached --quiet; then
+            echo "Dashboard unchanged — nothing to commit."
+            exit 0
+          fi
+          git commit -m "docs(audit): refresh clinical audit dashboard [skip ci]
+
+          Generated: $(date -u +%Y-%m-%d)
+          Flagged: ${{ steps.build.outputs.flagged_count }}
+          Stale reviews: ${{ steps.build.outputs.stale_count }}
+          Long-pending: triggered by ${{ github.event_name }}"
+          git push
+
+      - name: Annotate flagged functions
+        if: steps.build.outputs.flagged_count != '0'
+        run: |
+          echo "::warning::${{ steps.build.outputs.flagged_count }} clinical function(s) are flagged. Review audit-dashboard/DASHBOARD.md."
+
+      - name: Annotate stale reviews
+        if: steps.build.outputs.stale_count != '0'
+        run: |
+          echo "::warning::${{ steps.build.outputs.stale_count }} approved function(s) have been modified since last review. Re-review may be needed."
+
+      - name: Upload JSON report
+        if: always()
+        uses: actions/upload-artifact@v4  # v4.4.3
+        with:
+          name: audit-dashboard-${{ github.run_id }}
+          path: /tmp/audit_dashboard.json
+          retention-days: 90
+          if-no-files-found: ignore

--- a/.github/workflows/fda-bundle.yml
+++ b/.github/workflows/fda-bundle.yml
@@ -89,14 +89,20 @@ permissions:
 
 jobs:
   resolve-runner:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     outputs:
       labels: ${{ steps.p.outputs.labels }}
     steps:
       - id: p
+        env:
+          RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
-          IFS=',' read -ra L <<< "${{ inputs.runner-label }}"
-          echo "labels=$(printf '%s\n' "${L[@]}" | jq -Rn '[inputs]' | jq -c .)" >> "$GITHUB_OUTPUT"
+          python3 -c "
+import json, os
+labels = [l.strip() for l in os.environ['RUNNER_LABEL'].split(',') if l.strip()]
+with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    fh.write(f'labels={json.dumps(labels)}\n')
+"
 
   bundle:
     needs: resolve-runner

--- a/.github/workflows/fda-bundle.yml
+++ b/.github/workflows/fda-bundle.yml
@@ -90,6 +90,7 @@ permissions:
 jobs:
   resolve-runner:
     runs-on: [self-hosted, mac-studio, arm64]
+    timeout-minutes: 5
     outputs:
       labels: ${{ steps.p.outputs.labels }}
     steps:
@@ -98,6 +99,10 @@ jobs:
           RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
           labels=$(python3 -c "import json,os; L=os.environ.get('RUNNER_LABEL',''); print(json.dumps([x.strip() for x in L.split(',') if x.strip()]))")
+          if [ "$labels" = "[]" ]; then
+            echo "::error::inputs.runner-label parsed to an empty list — check the caller's runner-label value."
+            exit 1
+          fi
           echo "labels=$labels" >> "$GITHUB_OUTPUT"
 
   bundle:

--- a/.github/workflows/fda-bundle.yml
+++ b/.github/workflows/fda-bundle.yml
@@ -97,12 +97,8 @@ jobs:
         env:
           RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
-          python3 -c "
-import json, os
-labels = [l.strip() for l in os.environ['RUNNER_LABEL'].split(',') if l.strip()]
-with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-    fh.write(f'labels={json.dumps(labels)}\n')
-"
+          labels=$(python3 -c "import json,os; L=os.environ.get('RUNNER_LABEL',''); print(json.dumps([x.strip() for x in L.split(',') if x.strip()]))")
+          echo "labels=$labels" >> "$GITHUB_OUTPUT"
 
   bundle:
     needs: resolve-runner

--- a/.github/workflows/hipaa-compliance.yml
+++ b/.github/workflows/hipaa-compliance.yml
@@ -82,15 +82,20 @@ jobs:
   # 1. Resolve runner label input into a proper array
   # ──────────────────────────────────────────────────────────────────
   resolve-runner:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     outputs:
       labels: ${{ steps.parse.outputs.labels }}
     steps:
       - id: parse
+        env:
+          RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
-          IFS=',' read -ra LABELS <<< "${{ inputs.runner-label }}"
-          json=$(printf '%s\n' "${LABELS[@]}" | jq -Rn '[inputs]')
-          echo "labels=$(echo "$json" | jq -c .)" >> "$GITHUB_OUTPUT"
+          python3 -c "
+import json, os
+labels = [l.strip() for l in os.environ['RUNNER_LABEL'].split(',') if l.strip()]
+with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    fh.write(f'labels={json.dumps(labels)}\n')
+"
 
   # ──────────────────────────────────────────────────────────────────
   # 2. PHI / PII scan — custom regex pack for US medical data

--- a/.github/workflows/hipaa-compliance.yml
+++ b/.github/workflows/hipaa-compliance.yml
@@ -90,12 +90,8 @@ jobs:
         env:
           RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
-          python3 -c "
-import json, os
-labels = [l.strip() for l in os.environ['RUNNER_LABEL'].split(',') if l.strip()]
-with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-    fh.write(f'labels={json.dumps(labels)}\n')
-"
+          labels=$(python3 -c "import json,os; L=os.environ.get('RUNNER_LABEL',''); print(json.dumps([x.strip() for x in L.split(',') if x.strip()]))")
+          echo "labels=$labels" >> "$GITHUB_OUTPUT"
 
   # ──────────────────────────────────────────────────────────────────
   # 2. PHI / PII scan — custom regex pack for US medical data

--- a/.github/workflows/hipaa-compliance.yml
+++ b/.github/workflows/hipaa-compliance.yml
@@ -83,6 +83,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   resolve-runner:
     runs-on: [self-hosted, mac-studio, arm64]
+    timeout-minutes: 5
     outputs:
       labels: ${{ steps.parse.outputs.labels }}
     steps:
@@ -91,6 +92,10 @@ jobs:
           RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
           labels=$(python3 -c "import json,os; L=os.environ.get('RUNNER_LABEL',''); print(json.dumps([x.strip() for x in L.split(',') if x.strip()]))")
+          if [ "$labels" = "[]" ]; then
+            echo "::error::inputs.runner-label parsed to an empty list — check the caller's runner-label value."
+            exit 1
+          fi
           echo "labels=$labels" >> "$GITHUB_OUTPUT"
 
   # ──────────────────────────────────────────────────────────────────

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -66,12 +66,8 @@ jobs:
         env:
           RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
-          python3 -c "
-import json, os
-labels = [l.strip() for l in os.environ['RUNNER_LABEL'].split(',') if l.strip()]
-with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-    fh.write(f'labels={json.dumps(labels)}\n')
-"
+          labels=$(python3 -c "import json,os; L=os.environ.get('RUNNER_LABEL',''); print(json.dumps([x.strip() for x in L.split(',') if x.strip()]))")
+          echo "labels=$labels" >> "$GITHUB_OUTPUT"
 
   # ──────────────────────────────────────────────────────────────
   # 1. Verify the tagged commit passed the HIPAA compliance workflow

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -58,14 +58,20 @@ permissions:
 jobs:
 
   resolve-runner:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     outputs:
       labels: ${{ steps.p.outputs.labels }}
     steps:
       - id: p
+        env:
+          RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
-          IFS=',' read -ra L <<< "${{ inputs.runner-label }}"
-          echo "labels=$(printf '%s\n' "${L[@]}" | jq -Rn '[inputs]' | jq -c .)" >> "$GITHUB_OUTPUT"
+          python3 -c "
+import json, os
+labels = [l.strip() for l in os.environ['RUNNER_LABEL'].split(',') if l.strip()]
+with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    fh.write(f'labels={json.dumps(labels)}\n')
+"
 
   # ──────────────────────────────────────────────────────────────
   # 1. Verify the tagged commit passed the HIPAA compliance workflow

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -59,6 +59,7 @@ jobs:
 
   resolve-runner:
     runs-on: [self-hosted, mac-studio, arm64]
+    timeout-minutes: 5
     outputs:
       labels: ${{ steps.p.outputs.labels }}
     steps:
@@ -67,6 +68,10 @@ jobs:
           RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
           labels=$(python3 -c "import json,os; L=os.environ.get('RUNNER_LABEL',''); print(json.dumps([x.strip() for x in L.split(',') if x.strip()]))")
+          if [ "$labels" = "[]" ]; then
+            echo "::error::inputs.runner-label parsed to an empty list — check the caller's runner-label value."
+            exit 1
+          fi
           echo "labels=$labels" >> "$GITHUB_OUTPUT"
 
   # ──────────────────────────────────────────────────────────────

--- a/.github/workflows/repo-audit.yml
+++ b/.github/workflows/repo-audit.yml
@@ -69,6 +69,7 @@ permissions:
 jobs:
   resolve-runner:
     runs-on: [self-hosted, mac-studio, arm64]
+    timeout-minutes: 5
     outputs:
       labels: ${{ steps.parse.outputs.labels }}
     steps:
@@ -77,6 +78,10 @@ jobs:
           RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
           labels=$(python3 -c "import json,os; L=os.environ.get('RUNNER_LABEL',''); print(json.dumps([x.strip() for x in L.split(',') if x.strip()]))")
+          if [ "$labels" = "[]" ]; then
+            echo "::error::inputs.runner-label parsed to an empty list — check the caller's runner-label value."
+            exit 1
+          fi
           echo "labels=$labels" >> "$GITHUB_OUTPUT"
 
   audit:

--- a/.github/workflows/repo-audit.yml
+++ b/.github/workflows/repo-audit.yml
@@ -68,15 +68,20 @@ permissions:
 
 jobs:
   resolve-runner:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, mac-studio, arm64]
     outputs:
       labels: ${{ steps.parse.outputs.labels }}
     steps:
       - id: parse
+        env:
+          RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
-          IFS=',' read -ra LABELS <<< "${{ inputs.runner-label }}"
-          json=$(printf '%s\n' "${LABELS[@]}" | jq -Rn '[inputs]')
-          echo "labels=$(echo "$json" | jq -c .)" >> "$GITHUB_OUTPUT"
+          python3 -c "
+import json, os
+labels = [l.strip() for l in os.environ['RUNNER_LABEL'].split(',') if l.strip()]
+with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    fh.write(f'labels={json.dumps(labels)}\n')
+"
 
   audit:
     needs: resolve-runner

--- a/.github/workflows/repo-audit.yml
+++ b/.github/workflows/repo-audit.yml
@@ -76,12 +76,8 @@ jobs:
         env:
           RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
-          python3 -c "
-import json, os
-labels = [l.strip() for l in os.environ['RUNNER_LABEL'].split(',') if l.strip()]
-with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-    fh.write(f'labels={json.dumps(labels)}\n')
-"
+          labels=$(python3 -c "import json,os; L=os.environ.get('RUNNER_LABEL',''); print(json.dumps([x.strip() for x in L.split(',') if x.strip()]))")
+          echo "labels=$labels" >> "$GITHUB_OUTPUT"
 
   audit:
     needs: resolve-runner

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Install test deps
         run: |
           set -euo pipefail
-          pip install --quiet pytest "ruamel.yaml>=0.18,<0.19" "python-dateutil>=2.8"
+          pip install --quiet pytest "ruamel.yaml>=0.18,<0.19" "python-dateutil>=2.8" "jsonschema>=4.0"
 
       - name: Run pytest
         env:

--- a/audit-dashboard/DASHBOARD.md
+++ b/audit-dashboard/DASHBOARD.md
@@ -1,0 +1,6 @@
+# Clinical Audit Dashboard
+
+> This file is auto-generated weekly by `audit-dashboard-sweep.yml`.
+> It will be populated after the first workflow run.
+
+_No data yet — run `audit-dashboard-sweep.yml` via workflow_dispatch to generate the first report._

--- a/docs/grafana/dependency-health.json
+++ b/docs/grafana/dependency-health.json
@@ -1,0 +1,77 @@
+{
+  "__inputs": [
+    { "name": "DS_PROMETHEUS", "label": "Prometheus", "type": "datasource", "pluginId": "prometheus" }
+  ],
+  "title": "Dependency Health — Circuit Breakers & Bulkheads",
+  "uid": "rp-dependency-health",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(circuit_breaker_state, service)",
+        "refresh": 2,
+        "includeAll": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Circuit Breaker States",
+      "type": "table",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "circuit_breaker_state{service=~\"$service\"}",
+          "legendFormat": "{{service}} → {{dependency}}",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "renameByName": { "service": "Service", "dependency": "Dependency", "state": "State", "Value": "State Code" } } }
+      ]
+    },
+    {
+      "title": "Circuit Breaker Trips (rate/5m)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "rate(circuit_breaker_trips_total{service=~\"$service\"}[5m])",
+          "legendFormat": "{{service}} → {{dependency}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "title": "Bulkhead Rejections (rate/5m)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 6, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "rate(bulkhead_rejected_total{service=~\"$service\"}[5m])",
+          "legendFormat": "{{service}}/{{bulkhead}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "color": { "fixedColor": "orange", "mode": "fixed" } } }
+    },
+    {
+      "title": "Retry Attempts (rate/5m)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 6, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "rate(retry_attempts_total{service=~\"$service\"}[5m])",
+          "legendFormat": "{{service}} attempt {{attempt}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    }
+  ]
+}

--- a/docs/grafana/red-metrics.json
+++ b/docs/grafana/red-metrics.json
@@ -1,0 +1,89 @@
+{
+  "__inputs": [
+    { "name": "DS_PROMETHEUS", "label": "Prometheus", "type": "datasource", "pluginId": "prometheus" }
+  ],
+  "title": "RED Metrics — Rate, Errors, Duration",
+  "uid": "rp-red-metrics",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(http_requests_total, service)",
+        "refresh": 2
+      },
+      {
+        "name": "path",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(http_requests_total{service=\"$service\"}, path)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Rate (RPS)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 8, "h": 6 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"$service\",path=~\"$path\"}[1m])) by (method, path)",
+          "legendFormat": "{{method}} {{path}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "title": "Errors (RPS)",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 0, "w": 8, "h": 6 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_failed_total{service=\"$service\",path=~\"$path\"}[1m])) by (error_kind)",
+          "legendFormat": "{{error_kind}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "fixedColor": "red", "mode": "fixed" } } }
+    },
+    {
+      "title": "Duration Percentiles (ms)",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 0, "w": 8, "h": 6 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_ms_bucket{service=\"$service\",path=~\"$path\"}[5m])) by (le))",
+          "legendFormat": "P50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_ms_bucket{service=\"$service\",path=~\"$path\"}[5m])) by (le))",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_ms_bucket{service=\"$service\",path=~\"$path\"}[5m])) by (le))",
+          "legendFormat": "P99"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "title": "Latency Heatmap",
+      "type": "heatmap",
+      "gridPos": { "x": 0, "y": 6, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_request_duration_ms_bucket{service=\"$service\",path=~\"$path\"}[5m])) by (le)",
+          "legendFormat": "{{le}}",
+          "format": "heatmap"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/grafana/resource-utilization.json
+++ b/docs/grafana/resource-utilization.json
@@ -1,0 +1,117 @@
+{
+  "__inputs": [
+    { "name": "DS_PROMETHEUS", "label": "Prometheus", "type": "datasource", "pluginId": "prometheus" }
+  ],
+  "title": "Resource Utilization — CPU, Memory, Connections",
+  "uid": "rp-resource-util",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-3h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(process_cpu_seconds_total, service)",
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "CPU Usage %",
+      "type": "gauge",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "expr": "100 * rate(process_cpu_seconds_total{service=\"$service\"}[5m])",
+          "legendFormat": "CPU %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent", "min": 0, "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 70 },
+              { "color": "red",    "value": 90 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Memory RSS (MB)",
+      "type": "gauge",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{service=\"$service\"} / 1024 / 1024",
+          "legendFormat": "RSS MB"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decmbytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 768 },
+              { "color": "red",    "value": 1024 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Open File Descriptors",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "expr": "process_open_fds{service=\"$service\"}",
+          "legendFormat": "FDs"
+        }
+      ]
+    },
+    {
+      "title": "DB Connection Pool",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "db_pool_size{service=\"$service\"}",
+          "legendFormat": "Pool size"
+        },
+        {
+          "expr": "db_pool_idle{service=\"$service\"}",
+          "legendFormat": "Idle"
+        },
+        {
+          "expr": "db_pool_size{service=\"$service\"} - db_pool_idle{service=\"$service\"}",
+          "legendFormat": "In use"
+        }
+      ]
+    },
+    {
+      "title": "Tokio Thread Pool",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "tokio_worker_threads_total{service=\"$service\"}",
+          "legendFormat": "Worker threads"
+        },
+        {
+          "expr": "tokio_blocking_threads_total{service=\"$service\"}",
+          "legendFormat": "Blocking threads"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/grafana/resource-utilization.json
+++ b/docs/grafana/resource-utilization.json
@@ -32,7 +32,7 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percent", "min": 0, "max": 100,
+          "unit": "percent", "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/docs/grafana/service-health.json
+++ b/docs/grafana/service-health.json
@@ -1,0 +1,99 @@
+{
+  "__inputs": [
+    { "name": "DS_PROMETHEUS", "label": "Prometheus", "type": "datasource", "pluginId": "prometheus" }
+  ],
+  "title": "Service Health — Availability & Error Budget",
+  "uid": "rp-service-health",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(http_requests_total, service)",
+        "refresh": 2,
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Availability (30d rolling)",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "expr": "1 - (sum(rate(http_requests_total{service=\"$service\",status=~\"5..\"}[30d])) / sum(rate(http_requests_total{service=\"$service\"}[30d])))",
+          "legendFormat": "Availability"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "yellow", "value": 0.995 },
+              { "color": "green",  "value": 0.999 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Error Budget Remaining (30d)",
+      "type": "gauge",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "expr": "slo_error_budget_remaining_ratio{service=\"$service\"}",
+          "legendFormat": "Budget remaining"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0, "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "yellow", "value": 0.10 },
+              { "color": "green",  "value": 0.50 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Request Rate (RPS)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"$service\"}[5m])) by (status)",
+          "legendFormat": "HTTP {{status}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "title": "Error Rate %",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(http_requests_total{service=\"$service\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{service=\"$service\"}[5m]))",
+          "legendFormat": "5xx error %"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percent" } }
+    }
+  ]
+}

--- a/docs/observability/alert-rules.yaml
+++ b/docs/observability/alert-rules.yaml
@@ -12,15 +12,15 @@ groups:
         expr: |
           (
             1 - (
-              rate(http_requests_total{service="fhir-gateway",status!~"5.."}[1h])
-              / rate(http_requests_total{service="fhir-gateway"}[1h])
+              sum(rate(http_requests_total{service="fhir-gateway",status!~"5.."}[1h]))
+              / sum(rate(http_requests_total{service="fhir-gateway"}[1h]))
             )
           ) > (14.4 * 0.001)
           and
           (
             1 - (
-              rate(http_requests_total{service="fhir-gateway",status!~"5.."}[5m])
-              / rate(http_requests_total{service="fhir-gateway"}[5m])
+              sum(rate(http_requests_total{service="fhir-gateway",status!~"5.."}[5m]))
+              / sum(rate(http_requests_total{service="fhir-gateway"}[5m]))
             )
           ) > (14.4 * 0.001)
         for: 2m
@@ -38,15 +38,15 @@ groups:
         expr: |
           (
             1 - (
-              rate(http_requests_total{service="fhir-gateway",status!~"5.."}[6h])
-              / rate(http_requests_total{service="fhir-gateway"}[6h])
+              sum(rate(http_requests_total{service="fhir-gateway",status!~"5.."}[6h]))
+              / sum(rate(http_requests_total{service="fhir-gateway"}[6h]))
             )
           ) > (6 * 0.001)
           and
           (
             1 - (
-              rate(http_requests_total{service="fhir-gateway",status!~"5.."}[30m])
-              / rate(http_requests_total{service="fhir-gateway"}[30m])
+              sum(rate(http_requests_total{service="fhir-gateway",status!~"5.."}[30m]))
+              / sum(rate(http_requests_total{service="fhir-gateway"}[30m]))
             )
           ) > (6 * 0.001)
         for: 15m
@@ -90,8 +90,8 @@ groups:
         expr: |
           (
             1 - (
-              rate(http_requests_total{service="audit-log-writer",status!~"5.."}[5m])
-              / rate(http_requests_total{service="audit-log-writer"}[5m])
+              sum(rate(http_requests_total{service="audit-log-writer",status!~"5.."}[5m]))
+              / sum(rate(http_requests_total{service="audit-log-writer"}[5m]))
             )
           ) > (14.4 * 0.0001)
         for: 1m

--- a/docs/observability/alert-rules.yaml
+++ b/docs/observability/alert-rules.yaml
@@ -1,0 +1,140 @@
+---
+# Prometheus alert rules — multi-burn-rate SLO alerts
+# Based on Google SRE Workbook Chapter 5 (multi-window, multi-burn-rate).
+# Routing: critical → PagerDuty, warning → Slack #alerts-platform.
+
+groups:
+
+  - name: slo.fhir-gateway.availability
+    rules:
+      # Fast burn: consuming 2% of monthly budget in 1 h (burn rate 14.4x)
+      - alert: FhirGatewayAvailabilityCritical
+        expr: |
+          (
+            1 - (
+              rate(http_requests_total{service="fhir-gateway",status!~"5.."}[1h])
+              / rate(http_requests_total{service="fhir-gateway"}[1h])
+            )
+          ) > (14.4 * 0.001)
+          and
+          (
+            1 - (
+              rate(http_requests_total{service="fhir-gateway",status!~"5.."}[5m])
+              / rate(http_requests_total{service="fhir-gateway"}[5m])
+            )
+          ) > (14.4 * 0.001)
+        for: 2m
+        labels:
+          severity: critical
+          service: fhir-gateway
+          slo: availability
+          runbook: https://github.com/ruralpeds/.github/blob/main/docs/observability/runbooks/05-service-down.md
+        annotations:
+          summary: "FHIR Gateway: critical availability burn rate"
+          description: "Error rate is {{ $value | humanizePercentage }} — exhausting monthly error budget in < 2 h."
+
+      # Slow burn: consuming 10% of monthly budget in 6 h (burn rate 6x)
+      - alert: FhirGatewayAvailabilityWarning
+        expr: |
+          (
+            1 - (
+              rate(http_requests_total{service="fhir-gateway",status!~"5.."}[6h])
+              / rate(http_requests_total{service="fhir-gateway"}[6h])
+            )
+          ) > (6 * 0.001)
+          and
+          (
+            1 - (
+              rate(http_requests_total{service="fhir-gateway",status!~"5.."}[30m])
+              / rate(http_requests_total{service="fhir-gateway"}[30m])
+            )
+          ) > (6 * 0.001)
+        for: 15m
+        labels:
+          severity: warning
+          service: fhir-gateway
+          slo: availability
+          runbook: https://github.com/ruralpeds/.github/blob/main/docs/observability/runbooks/01-high-error-rate.md
+        annotations:
+          summary: "FHIR Gateway: elevated error rate"
+          description: "Sustained error rate consuming error budget at {{ $value | humanizePercentage }}."
+
+  - name: slo.fhir-gateway.latency
+    rules:
+      - alert: FhirGatewayLatencyCritical
+        expr: |
+          (
+            histogram_quantile(0.95,
+              rate(http_request_duration_ms_bucket{service="fhir-gateway",path!~"/healthz"}[5m])
+            ) > 500
+          )
+          and
+          (
+            histogram_quantile(0.95,
+              rate(http_request_duration_ms_bucket{service="fhir-gateway",path!~"/healthz"}[1h])
+            ) > 500
+          )
+        for: 5m
+        labels:
+          severity: critical
+          service: fhir-gateway
+          slo: latency_p95
+          runbook: https://github.com/ruralpeds/.github/blob/main/docs/observability/runbooks/04-high-latency.md
+        annotations:
+          summary: "FHIR Gateway: P95 latency > 500 ms"
+          description: "P95 latency is {{ $value }}ms — SLO threshold is 500ms."
+
+  - name: slo.audit-log-writer.availability
+    rules:
+      - alert: AuditLogWriterDown
+        expr: |
+          (
+            1 - (
+              rate(http_requests_total{service="audit-log-writer",status!~"5.."}[5m])
+              / rate(http_requests_total{service="audit-log-writer"}[5m])
+            )
+          ) > (14.4 * 0.0001)
+        for: 1m
+        labels:
+          severity: critical
+          service: audit-log-writer
+          slo: availability
+          runbook: https://github.com/ruralpeds/.github/blob/main/docs/observability/runbooks/05-service-down.md
+        annotations:
+          summary: "Audit log writer: availability SLO breach"
+          description: "Audit log writer error rate {{ $value | humanizePercentage }} — HIPAA audit continuity at risk."
+
+  - name: circuit-breaker
+    rules:
+      - alert: CircuitBreakerOpen
+        expr: circuit_breaker_state{state="open"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          runbook: https://github.com/ruralpeds/.github/blob/main/docs/observability/runbooks/03-circuit-breaker-open.md
+        annotations:
+          summary: "Circuit breaker open: {{ $labels.service }} → {{ $labels.dependency }}"
+          description: "Circuit breaker has been open for > 1 min. Upstream dependency may be degraded."
+
+  - name: slo-burn-rate
+    rules:
+      - alert: SloBudgetBurnRateHigh
+        expr: |
+          slo_error_budget_remaining_ratio < 0.10
+        for: 5m
+        labels:
+          severity: warning
+          runbook: https://github.com/ruralpeds/.github/blob/main/docs/observability/runbooks/02-slo-burn-rate.md
+        annotations:
+          summary: "SLO error budget < 10% remaining: {{ $labels.service }}/{{ $labels.slo }}"
+          description: "Only {{ $value | humanizePercentage }} of error budget remains for the rolling window."
+
+# Alert routing (Alertmanager config excerpt — full config in infra repo)
+# route:
+#   group_by: [service, slo]
+#   receiver: slack-platform
+#   routes:
+#     - match:
+#         severity: critical
+#       receiver: pagerduty-primary
+#       continue: true

--- a/docs/observability/log-schema.json
+++ b/docs/observability/log-schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ruralpeds/.github/blob/main/docs/observability/log-schema.json",
+  "title": "ruralpeds Structured Log Event",
+  "description": "Mandatory schema for every log line emitted by ruralpeds services. Apply logging-redaction.yaml before writing.",
+  "type": "object",
+  "required": ["timestamp", "service", "level", "event", "trace_id"],
+  "additionalProperties": true,
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp"
+    },
+    "service": {
+      "type": "string",
+      "description": "Service name (matches Prometheus job label)"
+    },
+    "level": {
+      "type": "string",
+      "enum": ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"]
+    },
+    "event": {
+      "type": "string",
+      "description": "snake_case event identifier, e.g. patient_created"
+    },
+    "trace_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{32}$",
+      "description": "W3C traceparent trace-id (hex, 128-bit)"
+    },
+    "span_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{16}$",
+      "description": "W3C traceparent parent-id (hex, 64-bit)"
+    },
+    "actor_id": {
+      "type": "string",
+      "description": "Internal user/service UUID — not a HIPAA identifier"
+    },
+    "resource_type": {
+      "type": "string",
+      "description": "FHIR resource type or internal domain object, e.g. Patient, Observation"
+    },
+    "resource_id": {
+      "type": "string",
+      "description": "Internal UUID of the affected resource"
+    },
+    "duration_ms": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Operation duration in milliseconds"
+    },
+    "http": {
+      "type": "object",
+      "properties": {
+        "method":      { "type": "string" },
+        "path":        { "type": "string" },
+        "status":      { "type": "integer" },
+        "request_id":  { "type": "string" }
+      }
+    },
+    "error": {
+      "type": "object",
+      "properties": {
+        "kind":    { "type": "string", "description": "Error type/variant" },
+        "message": { "type": "string" },
+        "stack":   { "type": "string", "description": "Redacted stack trace" }
+      }
+    },
+    "message": {
+      "type": "string",
+      "description": "Human-readable description (supplements event)"
+    }
+  }
+}

--- a/docs/observability/log-schema.json
+++ b/docs/observability/log-schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/ruralpeds/.github/blob/main/docs/observability/log-schema.json",
   "title": "ruralpeds Structured Log Event",
-  "description": "Mandatory schema for every log line emitted by ruralpeds services. Apply logging-redaction.yaml before writing.",
+  "description": "Mandatory schema for every log line emitted by ruralpeds services. Apply policies/logging-redaction.yaml before writing.",
   "type": "object",
   "required": ["timestamp", "service", "level", "event", "trace_id"],
   "additionalProperties": true,

--- a/docs/observability/runbooks/01-high-error-rate.md
+++ b/docs/observability/runbooks/01-high-error-rate.md
@@ -1,0 +1,47 @@
+# Runbook: High Error Rate (5xx)
+
+**Alert:** `FhirGatewayAvailabilityWarning` / `*AvailabilityCritical`
+**Severity:** Warning → Critical
+**Regulatory alignment:** IEC 62304 §8.2, HIPAA § 164.308(a)(6)
+
+---
+
+## Trigger Condition
+
+Error rate is consuming the monthly SLO error budget at an unsustainable burn rate:
+- **Warning:** 6× burn rate sustained for 15 min across 6h + 30m windows
+- **Critical:** 14.4× burn rate sustained for 2 min across 1h + 5m windows
+
+---
+
+## Diagnosis (< 5 min)
+
+```bash
+# 1. Identify which endpoints are failing
+kubectl exec -n prod deploy/fhir-gateway -- \
+  curl -s localhost:9090/metrics | grep 'http_requests_failed_total'
+
+# 2. Check recent error logs (PHI-redacted)
+kubectl logs -n prod deploy/fhir-gateway --since=10m | \
+  grep '"level":"ERROR"' | jq '{event,error,trace_id}'
+
+# 3. Check downstream dependencies
+kubectl exec -n prod deploy/fhir-gateway -- \
+  curl -s localhost:8080/healthz/dependencies | jq .
+```
+
+## Common Causes & Fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| 5xx on `/fhir/Patient` only | DB connection pool exhausted | Scale DB pool: `kubectl set env deploy/fhir-gateway DB_POOL_MAX=40` |
+| All endpoints returning 503 | Pod OOM-killed | Check `kubectl describe pod`; increase memory limit |
+| Auth-related 500s | Upstream OIDC provider down | Check `circuit_breaker_state{dependency="oidc"}` |
+| Spike then recovery | Bad deploy | `kubectl rollout undo deploy/fhir-gateway` |
+
+## Escalation
+
+If not resolved within **15 min** of page:
+1. Notify on-call clinical engineer via PagerDuty escalation
+2. Open P1 incident in Linear
+3. Post in `#incidents` Slack channel with trace_id from failing requests

--- a/docs/observability/runbooks/02-slo-burn-rate.md
+++ b/docs/observability/runbooks/02-slo-burn-rate.md
@@ -1,0 +1,57 @@
+# Runbook: SLO Error Budget < 10%
+
+**Alert:** `SloBudgetBurnRateHigh`
+**Severity:** Warning
+**Regulatory alignment:** IEC 62304 §8.2, NIST SP 800-53 SI-12
+
+---
+
+## Trigger Condition
+
+Less than 10% of the 30-day rolling error budget remains for a service SLO.
+This alert fires before Critical-level alerts — it is an early warning to
+investigate and stabilize before the budget exhausts completely.
+
+---
+
+## Diagnosis
+
+```bash
+# 1. Identify which SLO is burning
+# (Query Prometheus or check the Grafana service-health dashboard)
+# Filter: slo_error_budget_remaining_ratio{service=~".*"} < 0.10
+
+# 2. Pull error budget timeline for the past 7 days
+# Grafana: Dashboards > Service Health > Error Budget panel, set range to 7d
+
+# 3. Correlate with deploys
+kubectl rollout history deploy -n prod
+```
+
+## Decision Tree
+
+```
+Budget < 10%
+│
+├── Is the burn happening NOW (current error rate elevated)?
+│   YES → Follow runbook 01-high-error-rate.md
+│   NO  → Budget was consumed over the past week(s) — investigate historical incident(s)
+│
+├── Has a recent deploy correlated with the burn?
+│   YES → Consider rollback or hotfix; open postmortem
+│   NO  → Examine dependency health (runbook 03-circuit-breaker-open.md)
+│
+└── Is the SLO objective realistic?
+    → If traffic pattern changed permanently, schedule SLO review in next sprint
+```
+
+## Recovery Actions
+
+1. Identify and fix the root cause of errors (see runbook 01).
+2. If budget is < 5%, **freeze non-critical deploys** for the remainder of the window.
+3. Open a postmortem ticket in Linear tagged `slo-breach`.
+4. Review SLO objective at next monthly compliance review (see `docs/metrics/COMPLIANCE_METRICS.md`).
+
+## Escalation
+
+Budget < 5% → page on-call SRE immediately.

--- a/docs/observability/runbooks/03-circuit-breaker-open.md
+++ b/docs/observability/runbooks/03-circuit-breaker-open.md
@@ -1,0 +1,72 @@
+# Runbook: Circuit Breaker Open
+
+**Alert:** `CircuitBreakerOpen`
+**Severity:** Warning
+**Regulatory alignment:** IEC 62304 §8.2, NIST SP 800-53 SC-5
+
+---
+
+## Trigger Condition
+
+A `sci-resilience` circuit breaker has been in the `open` state for > 1 minute.
+When open, all calls to the protected dependency are rejected immediately (fail-fast),
+and callers receive a `CircuitBreakerError` rather than waiting for a timeout.
+
+## State Machine Reference
+
+```
+Closed ──(failure threshold exceeded)──► Open
+  ▲                                        │
+  │                                        │ (half-open probe timer)
+  └──(probe succeeds)── Half-Open ◄────────┘
+                             │
+                             └──(probe fails)──► Open
+```
+
+## Diagnosis
+
+```bash
+# 1. Which service/dependency is affected?
+# Alert label: service=X, dependency=Y
+
+# 2. Check if the dependency is actually down
+kubectl exec -n prod deploy/<service> -- \
+  curl -sv <dependency-health-url>/healthz 2>&1 | tail -5
+
+# 3. Check circuit breaker metrics
+# Grafana: Dependency Health dashboard > Circuit Breaker States panel
+
+# 4. Check recent trips
+kubectl exec -n prod deploy/<service> -- \
+  curl -s localhost:9090/metrics | grep circuit_breaker_trips_total
+```
+
+## Common Causes
+
+| Dependency | Common cause |
+|---|---|
+| Database | Connection pool exhausted, DB failover in progress |
+| OIDC provider | Token endpoint timeout; certificate expiry |
+| External FHIR server | Rate limiting, planned maintenance |
+| Audit log writer | Disk pressure on audit volume |
+
+## Resolution
+
+1. **If dependency is genuinely down:** Wait for it to recover. The circuit breaker
+   will automatically probe with a half-open request after the `half_open_timeout`
+   (default: 30 s). Do not force-reset unless instructed.
+
+2. **If dependency is healthy but breaker is stuck open:**
+   ```bash
+   # Force reset via admin endpoint (requires ADMIN_TOKEN)
+   kubectl exec -n prod deploy/<service> -- \
+     curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+     localhost:8080/admin/circuit-breaker/<dependency>/reset
+   ```
+
+3. **If this is a false positive** (dependency healthy, error threshold too low):
+   File a ticket to adjust `failure_threshold` or `timeout` in the `RetryPolicy` config.
+
+## Escalation
+
+Open circuit breaker affecting `audit-log-writer` → escalate immediately (HIPAA audit continuity risk).

--- a/docs/observability/runbooks/04-high-latency.md
+++ b/docs/observability/runbooks/04-high-latency.md
@@ -1,0 +1,61 @@
+# Runbook: High Latency (P95 > SLO Threshold)
+
+**Alert:** `FhirGatewayLatencyCritical` (and equivalent per-service alerts)
+**Severity:** Critical
+**Regulatory alignment:** IEC 62304 §8.2
+
+---
+
+## Trigger Condition
+
+P95 latency exceeds the SLO threshold (500 ms for fhir-gateway) sustained
+across both a 5-minute and a 1-hour window.
+
+---
+
+## Diagnosis
+
+```bash
+# 1. Identify the slow path (per endpoint breakdown)
+# Grafana: RED Metrics dashboard > Duration Percentiles, filter by path
+
+# 2. Pull a slow trace from Jaeger
+# Open Jaeger UI → search for service=fhir-gateway, min-duration=500ms
+
+# 3. Check if it's a DB issue
+kubectl exec -n prod deploy/fhir-gateway -- \
+  curl -s localhost:9090/metrics | grep 'db_query_duration_ms'
+
+# 4. Check bulkhead saturation (could cause queue buildup)
+kubectl exec -n prod deploy/fhir-gateway -- \
+  curl -s localhost:9090/metrics | grep 'bulkhead_'
+
+# 5. Check GC pressure (tokio blocking threads spike)
+kubectl exec -n prod deploy/fhir-gateway -- \
+  curl -s localhost:9090/metrics | grep 'tokio_blocking_threads'
+```
+
+## Latency Budget Breakdown (expected)
+
+| Component | P95 budget |
+|---|---|
+| Network (ingress → pod) | < 5 ms |
+| Auth middleware (OIDC verify) | < 20 ms |
+| DB query | < 100 ms |
+| Business logic | < 200 ms |
+| Response serialization | < 30 ms |
+| **Total** | **< 355 ms** (headroom to 500 ms SLO) |
+
+## Common Fixes
+
+| Root cause | Fix |
+|---|---|
+| DB query slow (missing index) | Check `EXPLAIN ANALYZE`; add index in a non-blocking migration |
+| DB pool contention | Increase `DB_POOL_MAX`; check for long-running transactions |
+| Downstream FHIR server slow | Check dependency health; consider increasing circuit breaker timeout |
+| Tokio blocking thread pool full | Increase `TOKIO_WORKER_THREADS`; move blocking I/O to `spawn_blocking` |
+| Large response payloads | Enable pagination; check `_count` parameter usage |
+
+## Escalation
+
+If P99 > 2 000 ms or patient-facing endpoints are affected → page on-call immediately.

--- a/docs/observability/runbooks/05-service-down.md
+++ b/docs/observability/runbooks/05-service-down.md
@@ -1,0 +1,90 @@
+# Runbook: Service Down / Unavailable
+
+**Alert:** `FhirGatewayAvailabilityCritical`, `AuditLogWriterDown`, and equivalents
+**Severity:** Critical (P1)
+**Regulatory alignment:** IEC 62304 §8.2, HIPAA § 164.308(a)(7), NIST SP 800-53 CP-10
+
+---
+
+## Trigger Condition
+
+Critical-level availability alert fired — the service is returning ≥ ~1.4% errors
+(fhir-gateway) or any errors (audit-log-writer), sustained for ≥ 2 minutes.
+
+---
+
+## Immediate Actions (< 3 min)
+
+```bash
+# 1. Check pod status
+kubectl get pods -n prod -l app=<service> --sort-by='.status.startTime'
+
+# 2. Check recent events
+kubectl get events -n prod --field-selector involvedObject.name=<pod-name> \
+  --sort-by='.lastTimestamp' | tail -20
+
+# 3. Check pod logs for crash reason
+kubectl logs -n prod deploy/<service> --previous --tail=50 | \
+  grep -E '"level":"(ERROR|FATAL)"' | jq '{event,error,trace_id}'
+
+# 4. Check node health
+kubectl get nodes -o wide
+kubectl describe node <node-name> | grep -A5 "Conditions:"
+```
+
+## Decision Tree
+
+```
+Service returning 5xx / not responding
+│
+├── Pods in CrashLoopBackOff?
+│   YES → Check logs (step 3 above); check OOMKilled: kubectl describe pod
+│   NO  ─┐
+│        ▼
+├── Pods Pending?
+│   YES → Node pressure? PVC not bound? → kubectl describe pod
+│   NO  ─┐
+│        ▼
+├── Pods Running but unhealthy?
+│   YES → Readiness probe failing → kubectl exec and curl /healthz
+│   NO  ─┐
+│        ▼
+└── Pods healthy but ingress failing?
+    YES → Check ingress controller / load balancer
+```
+
+## Recovery Procedures
+
+### Rollback a bad deploy
+```bash
+kubectl rollout undo deploy/<service> -n prod
+kubectl rollout status deploy/<service> -n prod --timeout=120s
+```
+
+### Force pod restart
+```bash
+kubectl rollout restart deploy/<service> -n prod
+```
+
+### Scale up replicas (if traffic surge)
+```bash
+kubectl scale deploy/<service> -n prod --replicas=6
+```
+
+## Special Case: Audit Log Writer Down
+
+If `audit-log-writer` is the affected service:
+1. **Immediately** notify compliance officer (HIPAA audit gap risk).
+2. Enable fallback local audit buffer if configured: `kubectl set env deploy/fhir-gateway AUDIT_FALLBACK_BUFFER=true`
+3. Do NOT restart more than once without investigating — repeated restarts may
+   corrupt the Merkle-chain sequence number.
+4. After recovery, verify chain integrity:
+   ```bash
+   python3 scripts/verify_audit_chain.py --from-last-checkpoint
+   ```
+
+## Post-Incident
+
+- File postmortem in Linear within 24 h of recovery.
+- Tag `p1-incident` and link to Grafana snapshot of the outage window.
+- Regulatory note: document incident timeline in DHF if service class ≥ B (IEC 62304).

--- a/docs/observability/runbooks/05-service-down.md
+++ b/docs/observability/runbooks/05-service-down.md
@@ -8,8 +8,10 @@
 
 ## Trigger Condition
 
-Critical-level availability alert fired — the service is returning ≥ ~1.4% errors
-(fhir-gateway) or any errors (audit-log-writer), sustained for ≥ 2 minutes.
+Critical-level availability alert fired — the service is returning sustained 5xx
+errors above the configured alert threshold (for `fhir-gateway`, approximately
+1.4%; for `audit-log-writer`, the burn-rate threshold defined by its 99.99% SLO)
+for ≥ 2 minutes.
 
 ---
 
@@ -80,7 +82,7 @@ If `audit-log-writer` is the affected service:
    corrupt the Merkle-chain sequence number.
 4. After recovery, verify chain integrity:
    ```bash
-   python3 scripts/verify_audit_chain.py --from-last-checkpoint
+   python3 scripts/chain/verify.py audit-log/chain.ndjson
    ```
 
 ## Post-Incident

--- a/docs/observability/slo.yaml
+++ b/docs/observability/slo.yaml
@@ -1,0 +1,65 @@
+---
+# Service Level Objectives — ruralpeds platform
+# Window: rolling 30 days. Burn-rate alerts defined in alert-rules.yaml.
+# Review cadence: monthly (see docs/metrics/COMPLIANCE_METRICS.md).
+
+version: "1.0"
+updated: "2026-05-01"
+
+defaults:
+  window: 30d
+  error_budget_policy: multi-burn-rate  # see alert-rules.yaml
+
+services:
+
+  - name: fhir-gateway
+    description: "FHIR R4 API gateway (primary patient data interface)"
+    slos:
+      - name: availability
+        objective: 99.9          # 43.8 min/month error budget
+        indicator:
+          metric: http_requests_total
+          good: 'http_requests_total{service="fhir-gateway",status!~"5.."}'
+          total: 'http_requests_total{service="fhir-gateway"}'
+      - name: latency_p95
+        objective: 99.0          # P95 < 500 ms
+        indicator:
+          metric: http_request_duration_ms
+          good: 'http_request_duration_ms_bucket{service="fhir-gateway",path!~"/healthz",le="500"}'
+          total: 'http_request_duration_ms_count{service="fhir-gateway",path!~"/healthz"}'
+
+  - name: phi-scan-service
+    description: "PHI detection service (runs inline on ingest)"
+    slos:
+      - name: availability
+        objective: 99.5
+        indicator:
+          metric: http_requests_total
+          good: 'http_requests_total{service="phi-scan-service",status!~"5.."}'
+          total: 'http_requests_total{service="phi-scan-service"}'
+      - name: latency_p99
+        objective: 95.0          # P99 < 2 000 ms (scan can be slow)
+        indicator:
+          metric: http_request_duration_ms
+          good: 'http_request_duration_ms_bucket{service="phi-scan-service",le="2000"}'
+          total: 'http_request_duration_ms_count{service="phi-scan-service"}'
+
+  - name: audit-log-writer
+    description: "Immutable Merkle-chain audit log writer"
+    slos:
+      - name: availability
+        objective: 99.99         # 4.4 min/month — zero audit gaps allowed
+        indicator:
+          metric: http_requests_total
+          good: 'http_requests_total{service="audit-log-writer",status!~"5.."}'
+          total: 'http_requests_total{service="audit-log-writer"}'
+
+  - name: gap-analysis-api
+    description: "Gap lifecycle API (reads/writes GAPS.md)"
+    slos:
+      - name: availability
+        objective: 99.0
+        indicator:
+          metric: http_requests_total
+          good: 'http_requests_total{service="gap-analysis-api",status!~"5.."}'
+          total: 'http_requests_total{service="gap-analysis-api"}'

--- a/policies/logging-redaction.yaml
+++ b/policies/logging-redaction.yaml
@@ -1,0 +1,79 @@
+---
+# PHI/PII field redaction rules for structured logging.
+# Every log emitter must apply these rules before writing to stdout/Loki.
+# Fields are matched by exact key name (case-insensitive) or JSON path.
+
+version: "1.0"
+updated: "2026-05-01"
+standard: "HIPAA § 164.514, 45 CFR § 164.312(a)(2)(iv)"
+
+redaction:
+  mode: replace          # replace | hash | drop
+  replacement: "[REDACTED]"
+  hash_algorithm: sha256 # used when mode=hash; HMAC key from secret REDACT_HMAC_KEY
+
+# Exact field names (case-insensitive match on JSON key)
+fields:
+  # HIPAA Safe Harbor identifiers (§ 164.514(b)(2))
+  - key: patient_name
+  - key: patient.name
+  - key: name
+    context: patient       # only when parent object is "patient"
+  - key: mrn
+  - key: medical_record_number
+  - key: ssn
+  - key: social_security_number
+  - key: dob
+  - key: date_of_birth
+  - key: birthdate
+  - key: email
+  - key: phone
+  - key: phone_number
+  - key: fax
+  - key: address
+  - key: street_address
+  - key: zip
+  - key: zip_code
+  - key: geo
+  - key: coordinates
+  - key: latitude
+  - key: longitude
+  - key: ip_address
+  - key: device_id
+  - key: account_number
+  - key: certificate_number
+  - key: license_number
+  - key: vehicle_id
+  - key: url
+    context: patient       # patient portal URLs may contain PHI
+  - key: biometric_id
+  - key: photo
+  - key: full_face_image
+
+# JSON path patterns (applied after exact-key pass)
+patterns:
+  - path: "$.patient.*"           # all fields under patient object
+  - path: "$.subject.identifier"  # FHIR subject identifiers
+  - path: "$.performer.identifier"
+  - path: "$.author.identifier"
+  - path: "$.request.headers.Authorization"
+  - path: "$.request.headers.Cookie"
+
+# Fields that must NEVER be redacted (allowlist overrides patterns above)
+allowlist:
+  - patient_id       # internal UUID — not a HIPAA direct identifier
+  - encounter_id
+  - observation_code # SNOMED/LOINC code, not PHI
+  - service_name
+  - trace_id
+  - span_id
+  - level
+  - timestamp
+  - event
+
+# Audit log exemption: audit-log.yml writes a subset of PHI to the
+# immutable audit chain under a separate HMAC-signed envelope.
+# Those writes bypass redaction and are governed by audit-sign-envelope.yml.
+audit_exemption:
+  workflow: audit-sign-envelope.yml
+  fields: [actor_id, resource_id, action]

--- a/policies/logging-redaction.yaml
+++ b/policies/logging-redaction.yaml
@@ -10,7 +10,8 @@ standard: "HIPAA § 164.514, 45 CFR § 164.312(a)(2)(iv)"
 redaction:
   mode: replace          # replace | hash | drop
   replacement: "[REDACTED]"
-  hash_algorithm: sha256 # used when mode=hash; HMAC key from secret REDACT_HMAC_KEY
+  hash_algorithm: hmac_sha256  # keyed hash, not plain SHA-256
+  hash_key_secret: REDACT_HMAC_KEY  # env var / secret name holding the HMAC key
 
 # Exact field names (case-insensitive match on JSON key)
 fields:

--- a/scripts/build_audit_dashboard.py
+++ b/scripts/build_audit_dashboard.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""
+build_audit_dashboard.py
+Rural Peds Clinical Audit Dashboard
+
+Fetches every .clinical-audit/registry.yaml in the org (Rust + Julia repos),
+aggregates stats, and writes a Markdown dashboard to stdout and optionally to
+a file for committing back to ruralpeds/.github.
+
+Usage:
+  python3 scripts/build_audit_dashboard.py --token ghp_... [--output DASHBOARD.md]
+
+Requires: Python 3.9+, requests (pip install requests)
+"""
+
+import argparse
+import base64
+import json
+import re
+import sys
+import time
+from datetime import date, datetime
+from pathlib import Path
+
+import requests
+
+ORG = "ruralpeds"
+TODAY = str(date.today())
+SCANNER_VERSION = "clinical_audit_scanner v1.0"
+
+SKIP_REPOS = {".github", "gap-analysis-standard", "gap-dashboard"}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GitHub API helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def api(method: str, path: str, token: str, **kwargs) -> requests.Response:
+    url = f"https://api.github.com{path}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    r = getattr(requests, method)(url, headers=headers, timeout=30, **kwargs)
+    if r.status_code == 403 and "rate limit" in r.text.lower():
+        reset = int(r.headers.get("X-RateLimit-Reset", time.time() + 60))
+        wait = max(reset - int(time.time()), 5)
+        print(f"  ⏳ Rate limited — sleeping {wait}s", file=sys.stderr, flush=True)
+        time.sleep(wait)
+        r = getattr(requests, method)(url, headers=headers, timeout=30, **kwargs)
+    return r
+
+
+def fetch_file(org: str, repo: str, path: str, token: str) -> str | None:
+    r = api("get", f"/repos/{org}/{repo}/contents/{path}", token)
+    if r.status_code == 404:
+        return None
+    if r.status_code != 200:
+        return None
+    data = r.json()
+    return base64.b64decode(data["content"]).decode("utf-8", errors="replace")
+
+
+def list_repos_by_language(org: str, languages: list[str], token: str) -> list[dict]:
+    """Return list of {name, language} dicts for all non-archived repos."""
+    all_repos: dict[str, dict] = {}
+    page = 1
+    while True:
+        r = api("get", f"/orgs/{org}/repos", token,
+                params={"per_page": 100, "page": page, "type": "all"})
+        r.raise_for_status()
+        batch = r.json()
+        if not batch:
+            break
+        for repo in batch:
+            if repo.get("archived"):
+                continue
+            lang = (repo.get("language") or "").lower()
+            if lang in [l.lower() for l in languages]:
+                name = repo["name"]
+                if name not in all_repos:
+                    all_repos[name] = {"name": name, "language": repo.get("language", "unknown")}
+        page += 1
+        if len(batch) < 100:
+            break
+    return list(all_repos.values())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Registry YAML parser
+# Targeted parser for the known output of clinical_audit_scanner.py.
+# No external deps.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _unquote(val: str) -> str:
+    val = val.strip()
+    if (val.startswith('"') and val.endswith('"')) or \
+       (val.startswith("'") and val.endswith("'")):
+        return val[1:-1]
+    return val
+
+
+def _parse_scalar(val: str) -> str | None:
+    val = val.strip()
+    if val in ("null", "~", ""):
+        return None
+    return _unquote(val)
+
+
+def parse_registry(text: str) -> dict:
+    """Parse a registry.yaml into a dict with a 'functions' list."""
+    registry: dict = {
+        "version": None,
+        "repo": None,
+        "language": None,
+        "last_scanned": None,
+        "generator": None,
+        "functions": [],
+    }
+
+    lines = text.splitlines()
+    i = 0
+    current_fn: dict | None = None
+    in_functions = False
+    in_review = False
+    in_validation = False
+    in_dates = False
+    in_references = False
+    current_ref: dict | None = None
+
+    def flush_fn():
+        nonlocal current_fn
+        if current_fn is not None:
+            registry["functions"].append(current_fn)
+        current_fn = None
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # Skip blank lines and comments
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+
+        indent = len(line) - len(line.lstrip())
+
+        # Top-level scalars
+        if indent == 0:
+            in_functions = False
+            in_review = False
+            in_validation = False
+            in_dates = False
+            in_references = False
+            current_ref = None
+
+            if stripped == "functions:":
+                flush_fn()
+                in_functions = True
+                i += 1
+                continue
+
+            if ":" in stripped:
+                key, _, val = stripped.partition(":")
+                key = key.strip()
+                if key in registry and key != "functions":
+                    registry[key] = _parse_scalar(val)
+
+        # Function list entry (indent=2, starts with "- ")
+        elif in_functions and indent == 2 and stripped.startswith("- "):
+            flush_fn()
+            in_review = False
+            in_validation = False
+            in_dates = False
+            in_references = False
+            current_ref = None
+            current_fn = {
+                "id": None, "name": None, "qualified": None, "file": None,
+                "line_start": None, "category": None, "signature": None,
+                "description": None,
+                "dates": {"first_commit": None, "last_modified": None, "last_reviewed": None},
+                "references": [],
+                "validation": {
+                    "has_tests": False, "test_files": [], "method": None,
+                    "iec62304_class": None, "last_validated": None, "validation_notes": None,
+                },
+                "review": {"status": None, "reviewer": None, "reviewed_at": None, "notes": None},
+            }
+            # parse inline key after "- "
+            rest = stripped[2:]
+            if ":" in rest:
+                key, _, val = rest.partition(":")
+                key = key.strip()
+                if key in current_fn:
+                    current_fn[key] = _parse_scalar(val)
+
+        # Function-level fields (indent=4)
+        elif current_fn is not None and indent == 4:
+            in_review = False
+            in_validation = False
+            in_dates = False
+            in_references = False
+            current_ref = None
+
+            if stripped == "review:":
+                in_review = True
+            elif stripped == "validation:":
+                in_validation = True
+            elif stripped == "dates:":
+                in_dates = True
+            elif stripped == "references:":
+                in_references = True
+            elif ":" in stripped:
+                key, _, val = stripped.partition(":")
+                key = key.strip()
+                if key in current_fn:
+                    current_fn[key] = _parse_scalar(val)
+                elif key == "line_start":
+                    try:
+                        current_fn["line_start"] = int(val.strip())
+                    except ValueError:
+                        pass
+
+        # Sub-section fields (indent=6)
+        elif current_fn is not None and indent == 6:
+            if in_review and ":" in stripped:
+                key, _, val = stripped.partition(":")
+                current_fn["review"][key.strip()] = _parse_scalar(val)
+            elif in_validation and ":" in stripped and not stripped.startswith("- "):
+                key, _, val = stripped.partition(":")
+                k = key.strip()
+                if k == "has_tests":
+                    current_fn["validation"]["has_tests"] = val.strip() == "true"
+                elif k == "iec62304_class":
+                    current_fn["validation"]["iec62304_class"] = _parse_scalar(val)
+                elif k == "method":
+                    current_fn["validation"]["method"] = _parse_scalar(val)
+                elif k == "last_validated":
+                    current_fn["validation"]["last_validated"] = _parse_scalar(val)
+                elif k == "validation_notes":
+                    current_fn["validation"]["validation_notes"] = _parse_scalar(val)
+            elif in_dates and ":" in stripped:
+                key, _, val = stripped.partition(":")
+                current_fn["dates"][key.strip()] = _parse_scalar(val)
+            elif in_references and stripped.startswith("- "):
+                # start a new reference entry
+                current_ref = {"type": None, "citation": None}
+                registry["functions"]  # just to avoid unused warning
+                rest = stripped[2:]
+                if ":" in rest:
+                    key, _, val = rest.partition(":")
+                    current_ref[key.strip()] = _parse_scalar(val)
+                current_fn["references"].append(current_ref)
+
+        # Reference sub-fields (indent=8)
+        elif current_fn is not None and indent == 8 and in_references and current_ref is not None:
+            if ":" in stripped:
+                key, _, val = stripped.partition(":")
+                current_ref[key.strip()] = _parse_scalar(val)
+
+        i += 1
+
+    flush_fn()
+    return registry
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Aggregation
+# ─────────────────────────────────────────────────────────────────────────────
+
+def days_between(date_str_a: str | None, date_str_b: str | None) -> int | None:
+    """Return (b - a).days, or None if either is missing."""
+    if not date_str_a or not date_str_b:
+        return None
+    try:
+        a = datetime.fromisoformat(date_str_a).date()
+        b = datetime.fromisoformat(date_str_b).date()
+        return (b - a).days
+    except ValueError:
+        return None
+
+
+def is_stale(fn: dict) -> bool:
+    """Approved function whose last_modified is newer than last_reviewed."""
+    if fn["review"]["status"] != "approved":
+        return False
+    diff = days_between(fn["dates"].get("last_reviewed"), fn["dates"].get("last_modified"))
+    return diff is not None and diff > 0
+
+
+def days_pending(fn: dict) -> int | None:
+    """Days since first_commit for a pending function."""
+    if fn["review"]["status"] != "pending":
+        return None
+    return days_between(fn["dates"].get("first_commit"), TODAY)
+
+
+def aggregate(registries: list[dict]) -> dict:
+    totals = {
+        "repos_with_registry": 0,
+        "total_functions": 0,
+        "by_status": {"pending": 0, "approved": 0, "flagged": 0, "not_applicable": 0},
+        "by_category": {},
+        "by_iec_class": {"A": 0, "B": 0, "C": 0, "unclassified": 0},
+        "flagged": [],       # {repo, fn}
+        "stale": [],         # {repo, fn}
+        "long_pending": [],  # {repo, fn, days}
+    }
+
+    for reg in registries:
+        if not reg.get("functions"):
+            continue
+        totals["repos_with_registry"] += 1
+        repo_name = reg.get("repo", "unknown")
+
+        for fn in reg["functions"]:
+            totals["total_functions"] += 1
+
+            status = fn["review"]["status"] or "pending"
+            totals["by_status"][status] = totals["by_status"].get(status, 0) + 1
+
+            cat = fn.get("category") or "unknown"
+            totals["by_category"][cat] = totals["by_category"].get(cat, 0) + 1
+
+            cls = fn["validation"].get("iec62304_class") or ""
+            if cls in ("A", "B", "C"):
+                totals["by_iec_class"][cls] += 1
+            else:
+                totals["by_iec_class"]["unclassified"] += 1
+
+            if status == "flagged":
+                totals["flagged"].append({"repo": repo_name, "fn": fn})
+
+            if is_stale(fn):
+                totals["stale"].append({"repo": repo_name, "fn": fn})
+
+            dp = days_pending(fn)
+            if dp is not None and dp > 30:
+                totals["long_pending"].append({"repo": repo_name, "fn": fn, "days": dp})
+
+    return totals
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Markdown generation
+# ─────────────────────────────────────────────────────────────────────────────
+
+def pct(n: int, total: int) -> str:
+    if total == 0:
+        return "—"
+    return f"{n / total * 100:.0f}%"
+
+
+def repo_short(full: str) -> str:
+    """ruralpeds/foo → foo"""
+    return full.split("/")[-1] if "/" in full else full
+
+
+def generate_markdown(registries: list[dict], totals: dict, scan_date: str) -> str:
+    lines: list[str] = []
+
+    # ── Header ────────────────────────────────────────────────────────────────
+    lines += [
+        f"# Clinical Audit Dashboard — {scan_date}",
+        "",
+        f"> Generated: {scan_date} &nbsp;|&nbsp; "
+        f"Repos with registry: **{totals['repos_with_registry']}** &nbsp;|&nbsp; "
+        f"Total functions tracked: **{totals['total_functions']}**",
+        "",
+    ]
+
+    # ── Org summary ───────────────────────────────────────────────────────────
+    tf = totals["total_functions"]
+    bs = totals["by_status"]
+    lines += [
+        "## Org Summary",
+        "",
+        "| Status | Count | Share |",
+        "|--------|------:|------:|",
+        f"| Approved | {bs.get('approved', 0)} | {pct(bs.get('approved', 0), tf)} |",
+        f"| Pending | {bs.get('pending', 0)} | {pct(bs.get('pending', 0), tf)} |",
+        f"| Flagged | {bs.get('flagged', 0)} | {pct(bs.get('flagged', 0), tf)} |",
+        f"| Not applicable | {bs.get('not_applicable', 0)} | {pct(bs.get('not_applicable', 0), tf)} |",
+        f"| **Total** | **{tf}** | 100% |",
+        "",
+    ]
+
+    # ── Per-repo table ────────────────────────────────────────────────────────
+    lines += [
+        "## Repositories",
+        "",
+        "| Repo | Lang | Functions | Approved | Pending | Flagged | Stale | Last Scanned |",
+        "|------|------|----------:|---------:|--------:|--------:|------:|--------------|",
+    ]
+    for reg in sorted(registries, key=lambda r: r.get("repo", "")):
+        fns = reg.get("functions", [])
+        if not fns and not reg.get("last_scanned"):
+            continue
+        rname = repo_short(reg.get("repo", "unknown"))
+        lang = reg.get("language", "?")
+        total = len(fns)
+        approved = sum(1 for f in fns if f["review"]["status"] == "approved")
+        pending = sum(1 for f in fns if (f["review"]["status"] or "pending") == "pending")
+        flagged = sum(1 for f in fns if f["review"]["status"] == "flagged")
+        stale_count = sum(1 for f in fns if is_stale(f))
+        scanned = reg.get("last_scanned") or "—"
+        lines.append(
+            f"| {rname} | {lang} | {total} | {approved} | {pending} | {flagged} | {stale_count} | {scanned} |"
+        )
+    lines.append("")
+
+    # ── Needs attention ───────────────────────────────────────────────────────
+    lines += ["## Needs Attention", ""]
+
+    # Flagged
+    lines += [f"### Flagged Functions ({len(totals['flagged'])})", ""]
+    if totals["flagged"]:
+        lines += [
+            "| Repo | Function | Reviewer | Notes |",
+            "|------|----------|----------|-------|",
+        ]
+        for item in totals["flagged"]:
+            fn = item["fn"]
+            reviewer = fn["review"]["reviewer"] or "—"
+            notes = (fn["review"]["notes"] or "").replace("|", "\\|")[:60]
+            lines.append(
+                f"| {repo_short(item['repo'])} | `{fn['name']}` | {reviewer} | {notes} |"
+            )
+    else:
+        lines.append("_No flagged functions._")
+    lines.append("")
+
+    # Stale reviews
+    lines += [f"### Stale Reviews ({len(totals['stale'])})", ""]
+    lines += [
+        "> Approved functions where `last_modified` is newer than `last_reviewed`.",
+        "",
+    ]
+    if totals["stale"]:
+        lines += [
+            "| Repo | Function | Last Reviewed | Last Modified |",
+            "|------|----------|---------------|---------------|",
+        ]
+        for item in totals["stale"]:
+            fn = item["fn"]
+            reviewed = fn["dates"].get("last_reviewed") or "—"
+            modified = fn["dates"].get("last_modified") or "—"
+            lines.append(
+                f"| {repo_short(item['repo'])} | `{fn['name']}` | {reviewed} | {modified} |"
+            )
+    else:
+        lines.append("_No stale reviews._")
+    lines.append("")
+
+    # Long-pending
+    lines += [f"### Long-Pending Reviews >30 days ({len(totals['long_pending'])})", ""]
+    if totals["long_pending"]:
+        lines += [
+            "| Repo | Function | Category | First Commit | Days Pending |",
+            "|------|----------|----------|--------------|-------------:|",
+        ]
+        for item in sorted(totals["long_pending"], key=lambda x: -x["days"]):
+            fn = item["fn"]
+            cat = fn.get("category") or "—"
+            first = fn["dates"].get("first_commit") or "—"
+            lines.append(
+                f"| {repo_short(item['repo'])} | `{fn['name']}` | {cat} | {first} | {item['days']} |"
+            )
+    else:
+        lines.append("_No functions pending >30 days._")
+    lines.append("")
+
+    # ── IEC 62304 class distribution ──────────────────────────────────────────
+    ic = totals["by_iec_class"]
+    lines += [
+        "## IEC 62304 Class Distribution",
+        "",
+        "| Class | Description | Count | Share |",
+        "|-------|-------------|------:|------:|",
+        f"| A | No injury possible | {ic['A']} | {pct(ic['A'], tf)} |",
+        f"| B | Non-serious injury possible | {ic['B']} | {pct(ic['B'], tf)} |",
+        f"| C | Death/serious injury possible | {ic['C']} | {pct(ic['C'], tf)} |",
+        f"| — | Unclassified | {ic['unclassified']} | {pct(ic['unclassified'], tf)} |",
+        "",
+    ]
+
+    # ── Category distribution ─────────────────────────────────────────────────
+    bc = totals["by_category"]
+    lines += [
+        "## Category Distribution",
+        "",
+        "| Category | Count | Share |",
+        "|----------|------:|------:|",
+    ]
+    for cat, count in sorted(bc.items(), key=lambda x: -x[1]):
+        lines.append(f"| {cat} | {count} | {pct(count, tf)} |")
+    lines.append("")
+
+    # ── Footer ────────────────────────────────────────────────────────────────
+    lines += [
+        "---",
+        "",
+        f"_Auto-generated by `build_audit_dashboard.py` on {scan_date}._  ",
+        "_Source: `.clinical-audit/registry.yaml` in each repo._",
+        "",
+    ]
+
+    return "\n".join(lines)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate org-wide clinical audit dashboard")
+    parser.add_argument("--token", required=True, help="GitHub PAT with repo read scope")
+    parser.add_argument("--org", default=ORG)
+    parser.add_argument("--output", help="Write markdown to this file path (in addition to stdout)")
+    parser.add_argument("--json-output", help="Write raw aggregated JSON to this path")
+    parser.add_argument("--repo", help="Limit to a single repo name (for testing)")
+    args = parser.parse_args()
+
+    if args.repo:
+        repos = [{"name": args.repo, "language": "unknown"}]
+    else:
+        print("Fetching repo list...", file=sys.stderr, flush=True)
+        repos = list_repos_by_language(args.org, ["Rust", "Julia"], args.token)
+        repos = [r for r in repos if r["name"] not in SKIP_REPOS]
+        print(f"Found {len(repos)} Rust/Julia repos", file=sys.stderr)
+
+    registries: list[dict] = []
+    for repo_info in repos:
+        name = repo_info["name"]
+        print(f"  Fetching {name}...", file=sys.stderr, end="", flush=True)
+        raw = fetch_file(args.org, name, ".clinical-audit/registry.yaml", args.token)
+        if raw is None:
+            print(" (no registry)", file=sys.stderr)
+            continue
+        try:
+            reg = parse_registry(raw)
+            reg.setdefault("repo", f"{args.org}/{name}")
+            reg.setdefault("language", repo_info["language"])
+            registries.append(reg)
+            fn_count = len(reg.get("functions", []))
+            print(f" {fn_count} function(s)", file=sys.stderr)
+        except Exception as e:
+            print(f" ERROR parsing: {e}", file=sys.stderr)
+        time.sleep(0.1)
+
+    print(f"\nAggregating {len(registries)} registries...", file=sys.stderr)
+    totals = aggregate(registries)
+    markdown = generate_markdown(registries, totals, TODAY)
+
+    # Always write to stdout (captured by workflow as step summary)
+    print(markdown)
+
+    if args.output:
+        Path(args.output).write_text(markdown)
+        print(f"Wrote dashboard to {args.output}", file=sys.stderr)
+
+    if args.json_output:
+        report = {
+            "generated": TODAY,
+            "repos_scanned": len(registries),
+            "totals": {
+                k: v for k, v in totals.items()
+                if k not in ("flagged", "stale", "long_pending")
+            },
+            "flagged_count": len(totals["flagged"]),
+            "stale_count": len(totals["stale"]),
+            "long_pending_count": len(totals["long_pending"]),
+        }
+        Path(args.json_output).write_text(json.dumps(report, indent=2))
+        print(f"Wrote JSON report to {args.json_output}", file=sys.stderr)
+
+    # Exit 1 if there are flagged functions — lets caller decide whether to fail
+    return 1 if totals["by_status"].get("flagged", 0) > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **`scripts/build_audit_dashboard.py`** — fetches every `.clinical-audit/registry.yaml` across all Rust/Julia repos, aggregates stats, and renders a structured Markdown dashboard
- **`.github/workflows/audit-dashboard-sweep.yml`** — runs Sunday 23:00 UTC + on demand; commits `audit-dashboard/DASHBOARD.md` to this repo and annotates flagged/stale counts
- **`audit-dashboard/DASHBOARD.md`** — placeholder replaced on first run

## Dashboard sections

| Section | What it shows |
|---------|--------------|
| Org Summary | Approved / Pending / Flagged / Not-applicable counts + share |
| Repositories | Per-repo function count, status breakdown, stale count, last scanned date |
| Flagged Functions | Each flagged function with reviewer and notes |
| Stale Reviews | Approved functions where `last_modified > last_reviewed` |
| Long-Pending (>30 days) | Pending functions by age, sorted descending |
| IEC 62304 Class Distribution | Class A/B/C/unclassified counts across the org |
| Category Distribution | clinical_calculation / statistics / scoring / reference_range counts |

## Workflow behaviour

- Writes full dashboard markdown to `$GITHUB_STEP_SUMMARY` (visible in Actions UI)
- Commits `audit-dashboard/DASHBOARD.md` to `main` on schedule and when `commit_dashboard=true`
- Emits `::warning` annotations when flagged or stale counts are non-zero
- Exits 1 (flagged functions found) is surfaced as a warning annotation, not a workflow failure
- Uploads JSON stats as a 90-day artifact (`audit-dashboard-<run_id>`)
- `--repo` flag allows single-repo spot-checks via `workflow_dispatch`

## Relationship to other workflows

```
Sunday 23:00 UTC    audit-dashboard-sweep   ← this PR
Monday 06:30 UTC    clinical-audit-sweep    (existing — scans all repos)
Monday 06:00 UTC    build-status-sweep      (existing — updates gap statuses)
```

## Test plan

- [ ] Run `workflow_dispatch` with `commit_dashboard=false` and verify step summary renders correctly
- [ ] Run against a repo that has a populated `registry.yaml` with mixed statuses
- [ ] Verify DASHBOARD.md is committed on schedule run
- [ ] Verify `::warning` fires when a flagged function is present

https://claude.ai/code/session_01BJaSEfzkFNvYJkTzmr4L2y

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJaSEfzkFNvYJkTzmr4L2y)_